### PR TITLE
Fix workers getting stuck on buildActions

### DIFF
--- a/src/overlords/core/overlord_work.ts
+++ b/src/overlords/core/overlord_work.ts
@@ -177,7 +177,7 @@ export class WorkerOverlord extends Overlord {
 				this.repairActions(worker);
 			} else if (this.colony.roadLogistics.workerShouldRepave(worker)) {
 				this.pavingActions(worker);
-			} else if (this.colony.constructionSites.length > 0) {
+			} else if (this.colony.constructionSites.length > 0 && _.some(this.colony.constructionSites, site => site.pos.roomName == this.colony.name)) {
 				this.buildActions(worker);
 			} else if (this.fortifyStructures.length > 0) {
 				this.fortifyActions(worker);


### PR DESCRIPTION


## Pull request summary
Workers get stuck on buildActions if the only construction sites are outpost containers.
### Brief description:
<!--- Include a brief description of the changes in this pull request here --->
buildActions function gets called but will not assign a worker to construction sites that are outpost mining containers.  The worker will then idle instead of upgrading or other actions instead of being assigned a task.
### At a glance:
- [x] This is a minor change      

<!--- Leave this unchecked if this does something like change memory structure --->
- [x] Changes are backwards-compatible  

<!--- Mark if this fixes a bug or behavioral vulnerability and should be reviewed quickly --->
- [ ] Changes are urgent                

### Added features:

- None

### Changes to existing features:
Workers will no longer idle trying to build construction sites that buildActions will not allow them to because they are outpost containers.

### Bugfixes: 


- None


## Testing checklist:


- [x] Codebase compiles with current `tsconfig` configuration
- [ ] Deployed and tested changes on public server 
