### PR TITLE
fix overlord looking at colony construction sites

### DIFF
--- a/src/overlords/core/overlord_work.ts
+++ b/src/overlords/core/overlord_work.ts
@@ -183,7 +183,7 @@ export class WorkerOverlord extends Overlord {
 				this.repairActions(worker);
 			} else if (this.colony.roadLogistics.workerShouldRepave(worker)) {
 				this.pavingActions(worker);
-			} else if (this.colony.constructionSites.length > 0) {
+			} else if (this.constructionSites.length > 0) {
 				this.buildActions(worker);
 			} else if (this.fortifyStructures.length > 0) {
 				this.fortifyActions(worker);


### PR DESCRIPTION
Worker overlord should look at its construction sites instead of colony

## Pull request summary

### Brief description:
<!--- Include a brief description of the changes in this pull request here --->
Fixes worker overlord still looking at colony construction sites instead of the newly sorted collection in its own properties
### At a glance:
<!--- Please mark items with [x] as applicable. (This is informational, not a checklist!) --->

<!--- Mark if this PR is small and doesn't change behavior, e.g. small bugfix, typo --->
- [x] This is a minor change      

<!--- Leave this unchecked if this does something like change memory structure --->
- [x] Changes are backwards-compatible  

<!--- Mark if this fixes a bug or behavioral vulnerability and should be reviewed quickly --->
- [ ] Changes are urgent                

### Added features:
<!--- Include new features added with this pull request here --->

- None

### Changes to existing features:
<!--- Describe changes to existing features here --->

Workers will be assigned build tasks based on the worker overlords sorted construction sites that omit outpost containers

### Bugfixes: 
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Codebase compiles with current `tsconfig` configuration
- [x] Deployed and tested changes on public server 
