### PR TITLE
Remove unowned and non-public extractors from Colony list

### DIFF
--- a/src/Colony.ts
+++ b/src/Colony.ts
@@ -178,6 +178,7 @@ export class Colony {
 								source => source.pos.getMultiRoomRangeTo(this.pos));
 		this.extractors = _.sortBy(_.compact(_.map(this.rooms, room => room.extractor)),
 								   extractor => extractor!.pos.getMultiRoomRangeTo(this.pos)) as StructureExtractor[];
+		_.remove(this.extractors, extractor => !extractor.my && !(extractor.owner.username == 'Public'));
 		this.constructionSites = _.flatten(_.map(this.rooms, room => room.constructionSites));
 		this.tombstones = _.flatten(_.map(this.rooms, room => room.tombstones));
 		this.repairables = _.flatten(_.map(this.rooms, room => room.repairables));


### PR DESCRIPTION
## Pull request summary

### Description:
<!--- Include a description of the changes in this pull request here --->
Removes unowned and non-public extractors from Colony to stop them from being managed by an Overlord

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- Colony will no longer create an Overlord for extractors in remote, non-SK rooms

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [ ] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

