### PR TITLE
Fix pioneer not withdrawing from derelict storage/terminal

### DIFF
--- a/src/overlords/colonization/pioneer.ts
+++ b/src/overlords/colonization/pioneer.ts
@@ -36,9 +36,9 @@ export class PioneerOverlord extends Overlord {
 	private rechargeActions(pioneer: Zerg) {
 		// Calculate recharge objects if needed (can't be placed in constructor because instantiation order
 		if (this.rechargeObjects.length == 0) {
-			let rechargeObjects = _.compact([pioneer.room.storageUnits,
-											 ...(pioneer.room.drops[RESOURCE_ENERGY] || []),
-											 ...pioneer.room.tombstones]) as rechargeObjectType[];
+			let rechargeObjects = _.compact([...pioneer.overlord!.room!.storageUnits,
+											 ...(pioneer.overlord!.room!.drops[RESOURCE_ENERGY] || []),
+											 ...pioneer.overlord!.room!.tombstones]) as rechargeObjectType[];
 			this.rechargeObjects = _.filter(rechargeObjects, obj => isResource(obj) ? obj.amount > 0 : obj.energy > 0);
 		}
 		// Choose the target to maximize your energy gain subject to other targeting workers


### PR DESCRIPTION
## Pull request summary
Fix pioneers not recharging from derelict storages and terminals
### Description:
<!--- Include a description of the changes in this pull request here --->
Pioneers were not accurately getting room.storageUnits[] before this edit

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- Pioneers will pull room.storageUnits[] which will allow them to withdraw from derelict storage and terminals containing energy


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on PUBLIC server OR changes are trivial (e.g. typos)

