### PR TITLE
Added logic changes to address issue #33.

### DIFF
--- a/src/Overseer.ts
+++ b/src/Overseer.ts
@@ -76,8 +76,10 @@ export class Overseer {
 			let hasMiners = this.colony.getCreepsByRole(MinerSetup.role).length > 0;		// Has energy supply?
 			let hasQueen = this.colony.getCreepsByRole(QueenSetup.role).length > 0;			// Has a queen?
 			if (!hasMiners && !hasQueen && this.colony.hatchery && !this.colony.spawnGroup) {
-				let energyToMakeQueen = bodyCost(QueenSetup.generateBody(this.colony.room.energyCapacityAvailable));
-				if (this.colony.room.energyAvailable < energyToMakeQueen) {
+				const energyToMakeQueen = bodyCost(QueenSetup.generateBody(this.colony.room.energyCapacityAvailable));
+				const totalStructures = this.colony.room.find(FIND_MY_STRUCTURES).length;
+				if ((totalStructures === 1 && Overmind.colonies.length === 1)
+					|| this.colony.room.energyAvailable < energyToMakeQueen) {
 					DirectiveBootstrap.createIfNotPresent(this.colony.hatchery.pos, 'pos');
 				}
 			}


### PR DESCRIPTION
## Merge changes to address issue #33 

### Description:
Alters bootstrap check logic to apply bootstrapping if there is energy to create a queen, but player has a single colony with a single structure.

### Added:
- None

### Changed:
- Bootstrapping logic in Overlord.ts:72-80(ish)

### Removed:
- None

### Fixed:
- #33 


## Testing checklist:
- [X ] Changes are backward-compatible OR version migration code is included
- [ X] Codebase compiles with current `tsconfig` configuration
- [ X] Tested changes on PRIVATE server

