### PR TITLE
Correct issue #33

### DIFF
--- a/src/Overseer.ts
+++ b/src/Overseer.ts
@@ -73,14 +73,21 @@ export class Overseer {
 		// Bootstrap directive: in the event of catastrophic room crash, enter emergency spawn mode.
 		// Doesn't apply to incubating colonies.
 		if (!this.colony.isIncubating) {
-			let hasMiners = this.colony.getCreepsByRole(MinerSetup.role).length > 0;		// Has energy supply?
-			let hasQueen = this.colony.getCreepsByRole(QueenSetup.role).length > 0;			// Has a queen?
+			const hasMiners = this.colony.getCreepsByRole(MinerSetup.role).length > 0;		// Has energy supply?
+			const hasQueen = this.colony.getCreepsByRole(QueenSetup.role).length > 0;			// Has a queen?
 			if (!hasMiners && !hasQueen && this.colony.hatchery && !this.colony.spawnGroup) {
 				const energyToMakeQueen = bodyCost(QueenSetup.generateBody(this.colony.room.energyCapacityAvailable));
-				const totalStructures = this.colony.room.find(FIND_MY_STRUCTURES).length;
-				if ((totalStructures === 1 && Overmind.colonies.length === 1)
+				const totalSpawns = Object.keys(Game.spawns).length;
+				const totalColonies = Object.keys(Overmind.colonies).length;
+				log.info("Spawns: " + totalSpawns + "; Colonies: " + totalColonies);
+				if ((totalSpawns === 1 && totalColonies === 1)
 					|| this.colony.room.energyAvailable < energyToMakeQueen) {
-					DirectiveBootstrap.createIfNotPresent(this.colony.hatchery.pos, 'pos');
+					const result = DirectiveBootstrap.createIfNotPresent(this.colony.hatchery.pos, 'pos');
+					let success = (result !== undefined);
+					success = success || (result === OK);
+					if (success) {
+						this.colony.hatchery.settings.suppressSpawning = true;
+					}
 				}
 			}
 		}

--- a/src/Overseer.ts
+++ b/src/Overseer.ts
@@ -76,8 +76,10 @@ export class Overseer {
 			let hasMiners = this.colony.getCreepsByRole(MinerSetup.role).length > 0;		// Has energy supply?
 			let hasQueen = this.colony.getCreepsByRole(QueenSetup.role).length > 0;			// Has a queen?
 			if (!hasMiners && !hasQueen && this.colony.hatchery && !this.colony.spawnGroup) {
-				let energyToMakeQueen = bodyCost(QueenSetup.generateBody(this.colony.room.energyCapacityAvailable));
-				if (this.colony.room.energyAvailable < energyToMakeQueen) {
+				const energyToMakeQueen = bodyCost(QueenSetup.generateBody(this.colony.room.energyCapacityAvailable));
+				const totalStructures = this.colony.room.find(FIND_MY_STRUCTURES).length;
+				if ((totalStructures === 1 && Overmind.colonies.length === 1)
+					|| this.colony.room.energyAvailable < energyToMakeQueen) {
 					DirectiveBootstrap.createIfNotPresent(this.colony.hatchery.pos, 'pos');
 				}
 			}


### PR DESCRIPTION
## Adjust bootstrap directive logic to not spawn queens on new players

### Description:
Adjusted Overseer.ts logic to skip queen spawn on new players

### Added:
- None

### Changed:
- Overseer.ts determines a new player by checking for a single spawn and a single colony.  In this case, suppresses spawning of queen and places bootstrap directive.

### Removed:
- None

### Fixed:
- #33 


## Testing checklist:
- [X] Changes are backward-compatible OR version migration code is included
- [X] Codebase compiles with current `tsconfig` configuration
- [X] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

