### PR TITLE
Fix for when the Terminal gets too full.

### DIFF
--- a/src/logistics/Energetics.ts
+++ b/src/logistics/Energetics.ts
@@ -12,7 +12,8 @@ export class Energetics {
 		},
 		terminal: {
 			total : {
-				cap: TERMINAL_CAPACITY - 50000
+				cap: TERMINAL_CAPACITY - 50000,
+				removeCap: TERMINAL_CAPACITY - 40000
 			},
 			energy: {
 				sendSize    : 25000,	// Send energy in chunks of this size

--- a/src/resources/Abathur.ts
+++ b/src/resources/Abathur.ts
@@ -14,6 +14,7 @@ export const priorityStockAmounts: { [key: string]: number } = {
 	XZH2O: 1000, 	// For dismantling
 	XKHO2: 1000, 	// For ranged attackers
 	XUH2O: 1000, 	// For attacking
+	G    : 2000, 	// For nukes
 	GHO2 : 1000, 	// (-50 % dmg taken)
 	LHO2 : 1000, 	// (+200 % heal)
 	ZHO2 : 1000, 	// (+200 % fat decr - speed)
@@ -26,6 +27,10 @@ export const priorityStockAmounts: { [key: string]: number } = {
 	ZH   : 1000, 	// (+100 % dismantle)
 	UH   : 1000, 	// (+100 % attack)
 	KO   : 1000, 	// (+100 % ranged attack)
+	OH   : 2000, 	// For basic compound
+	GH   : 2000, 	// For another basic compound
+	GH2O : 1000, 	// (+80 % upgrade)
+	XGH2O: 2000,	// For upgrades
 };
 
 export const wantedStockAmounts: { [key: string]: number } = {


### PR DESCRIPTION
## Pull request summary
1. Fix for when the terminal gets too full.
2. Fix for expected boolean return on supply actions.

### Description:
This was a fix when I converted over to overmind and my stash was full. The manager and queen had a hard time when the terminal was full. This fix has been awhile and it helps the terminal from getting to full and when energy is needed it won't get blocked out.

### Added:
- None

### Changed:
- None

### Removed:
- None

### Fixed:
- Boolean return for supply actions in manager.ts


## Testing checklist:
- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

