### PR TITLE
Fix worker downgrade too late

### DIFF
--- a/src/logistics/Energetics.ts
+++ b/src/logistics/Energetics.ts
@@ -12,7 +12,8 @@ export class Energetics {
 		},
 		terminal: {
 			total : {
-				cap: TERMINAL_CAPACITY - 50000
+				cap: TERMINAL_CAPACITY - 50000,
+				removeCap: TERMINAL_CAPACITY - 40000
 			},
 			energy: {
 				sendSize    : 25000,	// Send energy in chunks of this size

--- a/src/overlords/core/worker.ts
+++ b/src/overlords/core/worker.ts
@@ -263,7 +263,11 @@ export class WorkerOverlord extends Overlord {
 	private handleWorker(worker: Zerg) {
 		if (worker.carry.energy > 0) {
 			// Upgrade controller if close to downgrade
-			if (this.colony.controller.ticksToDowngrade <= 1000) {
+			let ticksToDowngrade = 1000;
+			if(this.colony.level >= 4) {
+				ticksToDowngrade = 10000;
+			}
+			if (this.colony.controller.ticksToDowngrade <= ticksToDowngrade) {
 				if (this.upgradeActions(worker)) return;
 			}
 			// Repair damaged non-road non-barrier structures

--- a/src/resources/Abathur.ts
+++ b/src/resources/Abathur.ts
@@ -14,6 +14,7 @@ export const priorityStockAmounts: { [key: string]: number } = {
 	XZH2O: 1000, 	// For dismantling
 	XKHO2: 1000, 	// For ranged attackers
 	XUH2O: 1000, 	// For attacking
+	G    : 2000, 	// For nukes
 	GHO2 : 1000, 	// (-50 % dmg taken)
 	LHO2 : 1000, 	// (+200 % heal)
 	ZHO2 : 1000, 	// (+200 % fat decr - speed)
@@ -26,6 +27,10 @@ export const priorityStockAmounts: { [key: string]: number } = {
 	ZH   : 1000, 	// (+100 % dismantle)
 	UH   : 1000, 	// (+100 % attack)
 	KO   : 1000, 	// (+100 % ranged attack)
+	OH   : 2000, 	// For basic compound
+	GH   : 2000, 	// For another basic compound
+	GH2O : 1000, 	// (+80 % upgrade)
+	XGH2O: 2000,	// For upgrades
 };
 
 export const wantedStockAmounts: { [key: string]: number } = {


### PR DESCRIPTION
## Pull request summary

### Description:
On larger controllers, the worker cannot get it to upgrade in time if it's at 1000. So, this will set it to 10K and seems to help out.

### Added:
- None

### Changed:
In worker, the handleWorker has a minor change.

### Removed:
- None

### Fixed:
- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

