### PR TITLE
Add Assimilation checks to Colonization

### DIFF
--- a/src/Overseer.ts
+++ b/src/Overseer.ts
@@ -23,6 +23,7 @@ import {Notifier} from './directives/Notifier';
 import {DirectiveColonize} from './directives/colony/colonize';
 import {CombatPlanner} from './strategy/CombatPlanner';
 import {DirectiveClearRoom} from './directives/colony/clearRoom';
+import { isString } from 'lodash';
 
 
 // export const DIRECTIVE_CHECK_FREQUENCY = 2;
@@ -272,7 +273,11 @@ export class Overseer implements IOverseer {
 				let sourcePositions = _.map(sourceCoords, src => derefCoords(src.c, roomName));
 				let sourceDistances = _.map(sourcePositions, pos => Pathing.distance(origin, pos));
 				if (_.any(sourceDistances, dist => dist == undefined
-												   || dist > Colony.settings.maxSourceDistance)) return false;
+					|| dist > Colony.settings.maxSourceDistance)) return false;
+				// Don't create outpost on-top of another Overmind user
+				if (isString(Game.rooms[roomName].owner) && Assimilator.isAssimilated(Game.rooms[roomName].owner!)) {
+					return false;
+				}
 				return _.sum(sourceDistances) / sourceDistances.length;
 			});
 

--- a/src/Overseer.ts
+++ b/src/Overseer.ts
@@ -1,29 +1,28 @@
-import {DirectiveGuard} from './directives/defense/guard';
-import {DirectiveBootstrap} from './directives/situational/bootstrap';
-import {profile} from './profiler/decorator';
-import {Colony, ColonyStage} from './Colony';
-import {Overlord} from './overlords/Overlord';
-import {Directive} from './directives/Directive';
-import {log} from './console/log';
-import {Pathing} from './movement/Pathing';
-import {DirectiveInvasionDefense} from './directives/defense/invasionDefense';
-import {DirectiveNukeResponse} from './directives/situational/nukeResponse';
-import {DirectiveTerminalEvacuateState} from './directives/terminalState/terminalState_evacuate';
-import {bodyCost} from './creepSetups/CreepSetup';
-import {LogisticsNetwork} from './logistics/LogisticsNetwork';
-import {Cartographer, ROOMTYPE_CONTROLLER, ROOMTYPE_SOURCEKEEPER} from './utilities/Cartographer';
-import {derefCoords, hasJustSpawned, minBy, onPublicServer} from './utilities/utils';
-import {DirectiveOutpost} from './directives/colony/outpost';
-import {Autonomy, getAutonomyLevel, Mem} from './memory/Memory';
-import {RoomIntel} from './intel/RoomIntel';
-import {Roles} from './creepSetups/setups';
-import {MUON, MY_USERNAME, USE_TRY_CATCH} from './~settings';
-import {DirectiveOutpostDefense} from './directives/defense/outpostDefense';
-import {Notifier} from './directives/Notifier';
-import {DirectiveColonize} from './directives/colony/colonize';
-import {CombatPlanner} from './strategy/CombatPlanner';
-import {DirectiveClearRoom} from './directives/colony/clearRoom';
-import { isString } from 'lodash';
+import { Colony, ColonyStage } from './Colony';
+import { log } from './console/log';
+import { bodyCost } from './creepSetups/CreepSetup';
+import { Roles } from './creepSetups/setups';
+import { Directive } from './directives/Directive';
+import { Notifier } from './directives/Notifier';
+import { DirectiveClearRoom } from './directives/colony/clearRoom';
+import { DirectiveColonize } from './directives/colony/colonize';
+import { DirectiveOutpost } from './directives/colony/outpost';
+import { DirectiveGuard } from './directives/defense/guard';
+import { DirectiveInvasionDefense } from './directives/defense/invasionDefense';
+import { DirectiveOutpostDefense } from './directives/defense/outpostDefense';
+import { DirectiveBootstrap } from './directives/situational/bootstrap';
+import { DirectiveNukeResponse } from './directives/situational/nukeResponse';
+import { DirectiveTerminalEvacuateState } from './directives/terminalState/terminalState_evacuate';
+import { RoomIntel } from './intel/RoomIntel';
+import { LogisticsNetwork } from './logistics/LogisticsNetwork';
+import { Autonomy, Mem, getAutonomyLevel } from './memory/Memory';
+import { Pathing } from './movement/Pathing';
+import { Overlord } from './overlords/Overlord';
+import { profile } from './profiler/decorator';
+import { CombatPlanner } from './strategy/CombatPlanner';
+import { Cartographer, ROOMTYPE_CONTROLLER, ROOMTYPE_SOURCEKEEPER } from './utilities/Cartographer';
+import { derefCoords, hasJustSpawned, minBy, onPublicServer } from './utilities/utils';
+import { MUON, MY_USERNAME, USE_TRY_CATCH } from './~settings';
 
 
 // export const DIRECTIVE_CHECK_FREQUENCY = 2;
@@ -275,7 +274,8 @@ export class Overseer implements IOverseer {
 				if (_.any(sourceDistances, dist => dist == undefined
 					|| dist > Colony.settings.maxSourceDistance)) return false;
 				// Don't create outpost on-top of another Overmind user
-				if (isString(Game.rooms[roomName].owner) && Assimilator.isAssimilated(Game.rooms[roomName].owner!)) {
+				if (typeof Game.rooms[this.pos.roomName].owner === 'string' && Assimilator.isAssimilated(Game.rooms[roomName].owner!)) {
+					log.debug(`Strategist triggered no outpost on overmind user ${Game.rooms[roomName].owner} for ${roomName}`)
 					return false;
 				}
 				return _.sum(sourceDistances) / sourceDistances.length;

--- a/src/directives/colony/colonize.ts
+++ b/src/directives/colony/colonize.ts
@@ -8,6 +8,7 @@ import {log} from '../../console/log';
 import {Roles} from '../../creepSetups/setups';
 import {Cartographer, ROOMTYPE_CONTROLLER} from '../../utilities/Cartographer';
 import {printRoomName} from '../../utilities/utils';
+import { isString } from 'lodash';
 
 
 /**
@@ -65,6 +66,12 @@ export class DirectiveColonize extends Directive {
 			// Remove the directive
 			this.remove();
 		}
+		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
+		if (isString(Game.rooms[this.pos.roomName].owner) && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
+			//this.remove();
+		}
+
 		if (Game.time % 10 == 2 && this.room && !!this.room.owner && this.room.owner != MY_USERNAME) {
 			log.notify(`Removing Colonize directive in ${this.pos.roomName}: room already owned by another player.`);
 			this.remove();

--- a/src/directives/colony/colonize.ts
+++ b/src/directives/colony/colonize.ts
@@ -1,14 +1,13 @@
-import {profile} from '../../profiler/decorator';
-import {Directive} from '../Directive';
-import {ClaimingOverlord} from '../../overlords/colonization/claimer';
-import {Colony} from '../../Colony';
-import {PioneerOverlord} from '../../overlords/colonization/pioneer';
-import {MY_USERNAME} from '../../~settings';
-import {log} from '../../console/log';
-import {Roles} from '../../creepSetups/setups';
-import {Cartographer, ROOMTYPE_CONTROLLER} from '../../utilities/Cartographer';
-import {printRoomName} from '../../utilities/utils';
-import { isString } from 'lodash';
+import { Colony } from '../../Colony';
+import { log } from '../../console/log';
+import { Roles } from '../../creepSetups/setups';
+import { ClaimingOverlord } from '../../overlords/colonization/claimer';
+import { PioneerOverlord } from '../../overlords/colonization/pioneer';
+import { profile } from '../../profiler/decorator';
+import { Cartographer, ROOMTYPE_CONTROLLER } from '../../utilities/Cartographer';
+import { printRoomName } from '../../utilities/utils';
+import { MY_USERNAME } from '../../~settings';
+import { Directive } from '../Directive';
 
 
 /**
@@ -67,7 +66,7 @@ export class DirectiveColonize extends Directive {
 			this.remove();
 		}
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (isString(Game.rooms[this.pos.roomName].owner) && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+		if (typeof Game.rooms[this.pos.roomName].owner === 'string' && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
 			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
 			//this.remove();
 		}

--- a/src/directives/colony/colonize.ts
+++ b/src/directives/colony/colonize.ts
@@ -66,9 +66,17 @@ export class DirectiveColonize extends Directive {
 			// Remove the directive
 			this.remove();
 		}
+
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!) || RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!)) {
-			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
+		let AssimilatedRoomOwner = (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && RoomIntel.roomOwnedBy(this.pos.roomName) != MY_USERNAME && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!))
+		let AssimilatedRoomReserved = (typeof RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && RoomIntel.roomReservedBy(this.pos.roomName) != MY_USERNAME && Assimilator.isAssimilated(RoomIntel.roomReservedBy(this.pos.roomName)!))
+		//log.debug(`${this.print} Owned by: ${RoomIntel.roomOwnedBy(this.pos.roomName)}, who is ${AssimilatedRoomOwner} Assimilated. Reserved by: ${RoomIntel.roomReservedBy(this.pos.roomName)}, who is ${AssimilatedRoomReserved} Assimilated`)
+		if (Game.time % 10 == 2 && AssimilatedRoomOwner) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user ${RoomIntel.roomOwnedBy(this.pos.roomName)}!`)
+			//this.remove();
+		}
+		else if (Game.time % 10 == 2 && AssimilatedRoomReserved) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user ${RoomIntel.roomReservedBy(this.pos.roomName)}!`)
 			//this.remove();
 		}
 

--- a/src/directives/colony/colonize.ts
+++ b/src/directives/colony/colonize.ts
@@ -1,6 +1,7 @@
 import { Colony } from '../../Colony';
 import { log } from '../../console/log';
 import { Roles } from '../../creepSetups/setups';
+import { RoomIntel } from '../../intel/RoomIntel';
 import { ClaimingOverlord } from '../../overlords/colonization/claimer';
 import { PioneerOverlord } from '../../overlords/colonization/pioneer';
 import { profile } from '../../profiler/decorator';
@@ -66,7 +67,7 @@ export class DirectiveColonize extends Directive {
 			this.remove();
 		}
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (typeof Game.rooms[this.pos.roomName].owner === 'string' && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+		if (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!) || RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!)) {
 			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
 			//this.remove();
 		}

--- a/src/directives/colony/incubate.ts
+++ b/src/directives/colony/incubate.ts
@@ -3,6 +3,9 @@ import {Directive} from '../Directive';
 import {ClaimingOverlord} from '../../overlords/colonization/claimer';
 import {Colony} from '../../Colony';
 import {SpawnGroup} from '../../logistics/SpawnGroup';
+import { isString } from 'lodash';
+import { MY_USERNAME } from '../../~settings';
+import { log } from '../../console/log';
 
 
 /**
@@ -42,6 +45,11 @@ export class DirectiveIncubate extends Directive {
 			if (this.incubatee.level >= 7 && this.incubatee.storage && this.incubatee.terminal) {
 				this.remove();
 			}
+		}
+		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
+		if (isString(Game.rooms[this.pos.roomName].owner) && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
+			//this.remove();
 		}
 	}
 }

--- a/src/directives/colony/incubate.ts
+++ b/src/directives/colony/incubate.ts
@@ -1,11 +1,10 @@
-import {profile} from '../../profiler/decorator';
-import {Directive} from '../Directive';
-import {ClaimingOverlord} from '../../overlords/colonization/claimer';
-import {Colony} from '../../Colony';
-import {SpawnGroup} from '../../logistics/SpawnGroup';
-import { isString } from 'lodash';
-import { MY_USERNAME } from '../../~settings';
+import { Colony } from '../../Colony';
 import { log } from '../../console/log';
+import { SpawnGroup } from '../../logistics/SpawnGroup';
+import { ClaimingOverlord } from '../../overlords/colonization/claimer';
+import { profile } from '../../profiler/decorator';
+import { MY_USERNAME } from '../../~settings';
+import { Directive } from '../Directive';
 
 
 /**
@@ -47,7 +46,7 @@ export class DirectiveIncubate extends Directive {
 			}
 		}
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (isString(Game.rooms[this.pos.roomName].owner) && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+		if (typeof Game.rooms[this.pos.roomName].owner === 'string' && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
 			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
 			//this.remove();
 		}

--- a/src/directives/colony/incubate.ts
+++ b/src/directives/colony/incubate.ts
@@ -5,6 +5,7 @@ import { SpawnGroup } from '../../logistics/SpawnGroup';
 import { ClaimingOverlord } from '../../overlords/colonization/claimer';
 import { profile } from '../../profiler/decorator';
 import { Directive } from '../Directive';
+import { MY_USERNAME } from '../../~settings';
 
 
 /**
@@ -45,9 +46,17 @@ export class DirectiveIncubate extends Directive {
 				this.remove();
 			}
 		}
+
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!) || RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!)) {
-			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
+		let AssimilatedRoomOwner = (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && RoomIntel.roomOwnedBy(this.pos.roomName) != MY_USERNAME && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!))
+		let AssimilatedRoomReserved = (typeof RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && RoomIntel.roomReservedBy(this.pos.roomName) != MY_USERNAME && Assimilator.isAssimilated(RoomIntel.roomReservedBy(this.pos.roomName)!))
+		//log.debug(`${this.print} Owned by: ${RoomIntel.roomOwnedBy(this.pos.roomName)}, who is ${AssimilatedRoomOwner} Assimilated. Reserved by: ${RoomIntel.roomReservedBy(this.pos.roomName)}, who is ${AssimilatedRoomReserved} Assimilated`)
+		if (Game.time % 10 == 2 && AssimilatedRoomOwner) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user ${RoomIntel.roomOwnedBy(this.pos.roomName)}!`)
+			//this.remove();
+		}
+		else if (Game.time % 10 == 2 && AssimilatedRoomReserved) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user ${RoomIntel.roomReservedBy(this.pos.roomName)}!`)
 			//this.remove();
 		}
 	}

--- a/src/directives/colony/incubate.ts
+++ b/src/directives/colony/incubate.ts
@@ -1,9 +1,9 @@
 import { Colony } from '../../Colony';
 import { log } from '../../console/log';
+import { RoomIntel } from '../../intel/RoomIntel';
 import { SpawnGroup } from '../../logistics/SpawnGroup';
 import { ClaimingOverlord } from '../../overlords/colonization/claimer';
 import { profile } from '../../profiler/decorator';
-import { MY_USERNAME } from '../../~settings';
 import { Directive } from '../Directive';
 
 
@@ -46,7 +46,7 @@ export class DirectiveIncubate extends Directive {
 			}
 		}
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (typeof Game.rooms[this.pos.roomName].owner === 'string' && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+		if (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!) || RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!)) {
 			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
 			//this.remove();
 		}

--- a/src/directives/colony/outpost.ts
+++ b/src/directives/colony/outpost.ts
@@ -1,4 +1,4 @@
-import { MY_USERNAME } from '~settings';
+import { MY_USERNAME } from '../../~settings';
 import { log } from '../../console/log';
 import { RoomIntel } from '../../intel/RoomIntel';
 import { ReservingOverlord } from '../../overlords/colonization/reserver';
@@ -6,7 +6,6 @@ import { StationaryScoutOverlord } from '../../overlords/scouting/stationary';
 import { profile } from '../../profiler/decorator';
 import { Cartographer, ROOMTYPE_CONTROLLER } from '../../utilities/Cartographer';
 import { Directive } from '../Directive';
-import { MY_USERNAME } from '../../~settings';
 
 /**
  * Claims a new room and incubates it from the nearest (or specified) colony

--- a/src/directives/colony/outpost.ts
+++ b/src/directives/colony/outpost.ts
@@ -6,6 +6,7 @@ import { StationaryScoutOverlord } from '../../overlords/scouting/stationary';
 import { profile } from '../../profiler/decorator';
 import { Cartographer, ROOMTYPE_CONTROLLER } from '../../utilities/Cartographer';
 import { Directive } from '../Directive';
+import { MY_USERNAME } from '../../~settings';
 
 /**
  * Claims a new room and incubates it from the nearest (or specified) colony
@@ -40,9 +41,17 @@ export class DirectiveOutpost extends Directive {
 			log.warning(`Removing ${this.print} since room is owned!`);
 			this.remove();
 		}
+
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!) || RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!)) {
-			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
+		let AssimilatedRoomOwner = (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && RoomIntel.roomOwnedBy(this.pos.roomName) != MY_USERNAME && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!))
+		let AssimilatedRoomReserved = (typeof RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && RoomIntel.roomReservedBy(this.pos.roomName) != MY_USERNAME && Assimilator.isAssimilated(RoomIntel.roomReservedBy(this.pos.roomName)!))
+		//log.debug(`${this.print} Owned by: ${RoomIntel.roomOwnedBy(this.pos.roomName)}, who is ${AssimilatedRoomOwner} Assimilated. Reserved by: ${RoomIntel.roomReservedBy(this.pos.roomName)}, who is ${AssimilatedRoomReserved} Assimilated`)
+		if (Game.time % 10 == 2 && AssimilatedRoomOwner) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user ${RoomIntel.roomOwnedBy(this.pos.roomName)}!`)
+			//this.remove();
+		}
+		else if (Game.time % 10 == 2 && AssimilatedRoomReserved) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user ${RoomIntel.roomReservedBy(this.pos.roomName)}!`)
 			//this.remove();
 		}
 

--- a/src/directives/colony/outpost.ts
+++ b/src/directives/colony/outpost.ts
@@ -1,12 +1,11 @@
-import {Directive} from '../Directive';
-import {profile} from '../../profiler/decorator';
-import {ReservingOverlord} from '../../overlords/colonization/reserver';
-import {StationaryScoutOverlord} from '../../overlords/scouting/stationary';
-import {Cartographer, ROOMTYPE_CONTROLLER} from '../../utilities/Cartographer';
-import {RoomIntel} from '../../intel/RoomIntel';
-import {log} from '../../console/log';
-import { isString } from 'lodash'
 import { MY_USERNAME } from '~settings';
+import { log } from '../../console/log';
+import { RoomIntel } from '../../intel/RoomIntel';
+import { ReservingOverlord } from '../../overlords/colonization/reserver';
+import { StationaryScoutOverlord } from '../../overlords/scouting/stationary';
+import { profile } from '../../profiler/decorator';
+import { Cartographer, ROOMTYPE_CONTROLLER } from '../../utilities/Cartographer';
+import { Directive } from '../Directive';
 
 /**
  * Claims a new room and incubates it from the nearest (or specified) colony
@@ -42,7 +41,7 @@ export class DirectiveOutpost extends Directive {
 			this.remove();
 		}
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (isString(Game.rooms[this.pos.roomName].owner) && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+		if (typeof Game.rooms[this.pos.roomName].owner === 'string' && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
 			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
 			//this.remove();
 		}

--- a/src/directives/colony/outpost.ts
+++ b/src/directives/colony/outpost.ts
@@ -5,6 +5,8 @@ import {StationaryScoutOverlord} from '../../overlords/scouting/stationary';
 import {Cartographer, ROOMTYPE_CONTROLLER} from '../../utilities/Cartographer';
 import {RoomIntel} from '../../intel/RoomIntel';
 import {log} from '../../console/log';
+import { isString } from 'lodash'
+import { MY_USERNAME } from '~settings';
 
 /**
  * Claims a new room and incubates it from the nearest (or specified) colony
@@ -39,6 +41,12 @@ export class DirectiveOutpost extends Directive {
 			log.warning(`Removing ${this.print} since room is owned!`);
 			this.remove();
 		}
+		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
+		if (isString(Game.rooms[this.pos.roomName].owner) && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
+			//this.remove();
+		}
+
 		if (Game.time % 10 == 3 && this.room && this.room.controller
 			&& !this.pos.isEqualTo(this.room.controller.pos) && !this.memory.setPosition) {
 			this.setPosition(this.room.controller.pos);

--- a/src/directives/colony/outpost.ts
+++ b/src/directives/colony/outpost.ts
@@ -41,7 +41,7 @@ export class DirectiveOutpost extends Directive {
 			this.remove();
 		}
 		// if reserved or owned by Overmind user - throw warning but don't remove? Included code to remove, just commented out.
-		if (typeof Game.rooms[this.pos.roomName].owner === 'string' && Game.rooms[this.pos.roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[this.pos.roomName].owner!)) {
+		if (typeof RoomIntel.roomOwnedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!) || RoomIntel.roomReservedBy(this.pos.roomName) === 'string' && Assimilator.isAssimilated(RoomIntel.roomOwnedBy(this.pos.roomName)!)) {
 			log.warning(`${this.print} is in a room controlled by another Overmind user!`)
 			//this.remove();
 		}

--- a/src/strategy/Strategist.ts
+++ b/src/strategy/Strategist.ts
@@ -1,15 +1,14 @@
-import {Autonomy, getAutonomyLevel, Mem} from '../memory/Memory';
-import {Colony, getAllColonies} from '../Colony';
-import {DirectiveColonize} from '../directives/colony/colonize';
-import {Cartographer} from '../utilities/Cartographer';
-import {MIN_EXPANSION_DISTANCE} from './ExpansionPlanner';
-import {maxBy} from '../utilities/utils';
-import {log} from '../console/log';
-import {Pathing} from '../movement/Pathing';
-import {assimilationLocked} from '../assimilation/decorator';
-import {MAX_OWNED_ROOMS, SHARD3_MAX_OWNED_ROOMS, MY_USERNAME} from '../~settings';
-import {profile} from '../profiler/decorator';
-import { isString } from 'lodash';
+import { Colony, getAllColonies } from '../Colony';
+import { assimilationLocked } from '../assimilation/decorator';
+import { log } from '../console/log';
+import { DirectiveColonize } from '../directives/colony/colonize';
+import { Autonomy, Mem, getAutonomyLevel } from '../memory/Memory';
+import { Pathing } from '../movement/Pathing';
+import { profile } from '../profiler/decorator';
+import { Cartographer } from '../utilities/Cartographer';
+import { maxBy } from '../utilities/utils';
+import { MAX_OWNED_ROOMS, MY_USERNAME, SHARD3_MAX_OWNED_ROOMS } from '../~settings';
+import { MIN_EXPANSION_DISTANCE } from './ExpansionPlanner';
 
 
 const CHECK_EXPANSION_FREQUENCY = 1000;
@@ -117,8 +116,9 @@ export class Strategist implements IStrategist {
 				}
 
 				// Are there other Overmind users nearby?
-				if (_.any(adjacentRooms, roomName => isString(Game.rooms[roomName].owner) && Game.rooms[roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[roomName].owner!))) {
+				if (_.any(adjacentRooms, roomName => typeof Game.rooms[roomName].owner === 'string' && Game.rooms[roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[roomName].owner!))) {
 					score -= TOO_CLOSE_PENALTY;
+					log.debug(`Strategist triggered too close to overmind user ${Game.rooms[roomName].owner} for ${roomName}`)
 				}
 
 				// Reward new minerals and catalyst rooms

--- a/src/strategy/Strategist.ts
+++ b/src/strategy/Strategist.ts
@@ -7,8 +7,9 @@ import {maxBy} from '../utilities/utils';
 import {log} from '../console/log';
 import {Pathing} from '../movement/Pathing';
 import {assimilationLocked} from '../assimilation/decorator';
-import {MAX_OWNED_ROOMS, SHARD3_MAX_OWNED_ROOMS} from '../~settings';
+import {MAX_OWNED_ROOMS, SHARD3_MAX_OWNED_ROOMS, MY_USERNAME} from '../~settings';
 import {profile} from '../profiler/decorator';
+import { isString } from 'lodash';
 
 
 const CHECK_EXPANSION_FREQUENCY = 1000;
@@ -114,6 +115,12 @@ export class Strategist implements IStrategist {
 				if (_.any(adjacentRooms, roomName => Memory.rooms[roomName][_RM.AVOID])) {
 					continue;
 				}
+
+				// Are there other Overmind users nearby?
+				if (_.any(adjacentRooms, roomName => isString(Game.rooms[roomName].owner) && Game.rooms[roomName].owner != MY_USERNAME && Assimilator.isAssimilated(Game.rooms[roomName].owner!))) {
+					score -= TOO_CLOSE_PENALTY;
+				}
+
 				// Reward new minerals and catalyst rooms
 				let mineralType = Memory.rooms[roomName][_RM.MINERAL]
 								  ? Memory.rooms[roomName][_RM.MINERAL]![_RM_MNRL.MINERALTYPE]


### PR DESCRIPTION
## Pull request summary

### Description:
<!--- Include a description of the changes in this pull request here --->
I have added assimilation checks to the three colonization directives and the strategist
This is an attempt to getting Overmind to play better when neighboring other Overmind users.

I am open to additional things you want me to try and get this implemented on - I have only thought about the colonization directives - or if there is better ways for my code.

### Added:
<!--- Include new features added with this pull request here --->

- Assimilation checks to the following directives which checks if they are in a room owned or reserved by another assimilated user:
  - [colonize.ts]()
  - [incubate.ts]()
  - [outpost.ts]()


### Changed:
<!--- Describe changes to existing features here --->
- Modified the following directives:
  - [colonize.ts]()
  - [incubate.ts]()
  - [outpost.ts]()
- Modified the strategist.ts

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [ ] Changes are backward-compatible OR version migration code is included
  **Not sure how to check this?**
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on **PUBLIC** server OR changes are trivial (e.g. typos)
  **Still currently testing strategist.ts, will update once done - looking for feedback currently**
