### PR TITLE
Adding task to recover terminal resources on founding new room

### DIFF
--- a/src/roomPlanner/RoomPlanner.ts
+++ b/src/roomPlanner/RoomPlanner.ts
@@ -10,12 +10,13 @@ import {BarrierPlanner} from './BarrierPlanner';
 import {BuildPriorities, DemolishStructurePriorities} from '../priorities/priorities_structures';
 import {bunkerLayout} from './layouts/bunker';
 import {DirectiveTerminalRebuildState} from '../directives/terminalState/terminalState_rebuild';
-import {derefCoords, maxBy, onPublicServer} from '../utilities/utils';
+import {derefCoords, hasMinerals, maxBy, onPublicServer} from '../utilities/utils';
 import {bullet} from '../utilities/stringConstants';
 import {Pathing} from '../movement/Pathing';
 import {isOwnedStructure} from '../declarations/typeGuards';
 import {MY_USERNAME} from '../~settings';
 import {Energetics} from '../logistics/Energetics';
+import {DirectiveHaul} from "../directives/resource/haul";
 
 export interface BuildingPlannerOutput {
 	name: string;
@@ -597,6 +598,11 @@ export class RoomPlanner {
 					if (this.colony.level < 4
 						&& (structureType == STRUCTURE_STORAGE || structureType == STRUCTURE_TERMINAL)) {
 						break; // don't destroy terminal or storage when under RCL4 - can use energy inside
+					}
+					if (this.colony.level < 6
+						&& structureType == STRUCTURE_TERMINAL && hasMinerals((<StructureTerminal> structure).store)) {
+						DirectiveHaul.create(structure.pos);
+						break; // don't destroy terminal when under RCL6 if there are resources available.
 					}
 					if (structureType != STRUCTURE_WALL && structureType != STRUCTURE_RAMPART) {
 						this.memory.relocating = true;


### PR DESCRIPTION
## Pull request summary

### Description:
Doesn't destroy terminal if there are resources left and creates a haul directive under it.

Untested because my test room leveled up with wrong branch active 😬
