### PR TITLE
BugFix - Colonization directive must only assign a colony with a spawn structure

### DIFF
--- a/src/directives/colony/colonize.ts
+++ b/src/directives/colony/colonize.ts
@@ -30,7 +30,7 @@ export class DirectiveColonize extends Directive {
 
 	constructor(flag: Flag) {
 		super(flag, colony => colony.level >= DirectiveColonize.requiredRCL
-							  && colony.name != Directive.getPos(flag).roomName);
+							  && colony.name != Directive.getPos(flag).roomName && colony.spawns.length > 0);
 		// Register incubation status
 		this.toColonize = this.room ? Overmind.colonies[Overmind.colonyMap[this.room.name]] : undefined;
 		// Remove if misplaced


### PR DESCRIPTION
## Pull request summary

### Description:
When having two destroyed room next to each other, the automatic colonization directive can assign a room with no spawn to the directive.

### Added:
This PR has updated the filter in colonize constructor to exclude colonies without a spawn structure. 


### Changed:
<!--- Describe changes to existing features here --->
- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->
No issueNo
		super(flag, colony => colony.level >= DirectiveColonize.requiredRCL
							  && colony.name != Directive.getPos(flag).roomName && colony.spawns.length > 0);



## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

