### PR TITLE
BugFix - allow drop mining after room wipe @ RCL >3

### DIFF
--- a/src/directives/colony/colonize.ts
+++ b/src/directives/colony/colonize.ts
@@ -30,7 +30,7 @@ export class DirectiveColonize extends Directive {
 
 	constructor(flag: Flag) {
 		super(flag, colony => colony.level >= DirectiveColonize.requiredRCL
-							  && colony.name != Directive.getPos(flag).roomName && colony.spawns.length > 0);
+							  && colony.name != Directive.getPos(flag).roomName);
 		// Register incubation status
 		this.toColonize = this.room ? Overmind.colonies[Overmind.colonyMap[this.room.name]] : undefined;
 		// Remove if misplaced

--- a/src/directives/colony/colonize.ts
+++ b/src/directives/colony/colonize.ts
@@ -30,7 +30,7 @@ export class DirectiveColonize extends Directive {
 
 	constructor(flag: Flag) {
 		super(flag, colony => colony.level >= DirectiveColonize.requiredRCL
-							  && colony.name != Directive.getPos(flag).roomName);
+							  && colony.name != Directive.getPos(flag).roomName && colony.spawns.length > 0);
 		// Register incubation status
 		this.toColonize = this.room ? Overmind.colonies[Overmind.colonyMap[this.room.name]] : undefined;
 		// Remove if misplaced

--- a/src/overlords/mining/miner.ts
+++ b/src/overlords/mining/miner.ts
@@ -84,7 +84,7 @@ export class MiningOverlord extends Overlord {
 		this.minersNeeded = Math.min(Math.ceil(this.miningPowerNeeded / miningPowerEach),
 									 this.pos.availableNeighbors(true).length);
 		// Allow drop mining at low levels
-		this.allowDropMining = this.colony.level < MiningOverlord.settings.dropMineUntilRCL;
+		this.allowDropMining = this.colony.level < MiningOverlord.settings.dropMineUntilRCL || (this.colony.level > MiningOverlord.settings.dropMineUntilRCL && this.colony.extensions.length < 10); ;
 		if (this.mode != 'early' && !this.allowDropMining) {
 			if (this.container) {
 				this.harvestPos = this.container.pos;

--- a/src/overlords/mining/miner.ts
+++ b/src/overlords/mining/miner.ts
@@ -84,7 +84,7 @@ export class MiningOverlord extends Overlord {
 		this.minersNeeded = Math.min(Math.ceil(this.miningPowerNeeded / miningPowerEach),
 									 this.pos.availableNeighbors(true).length);
 		// Allow drop mining at low levels
-		this.allowDropMining = this.colony.level < MiningOverlord.settings.dropMineUntilRCL || (this.colony.level > MiningOverlord.settings.dropMineUntilRCL && this.colony.extensions.length < 10); ;
+		this.allowDropMining = this.colony.level < MiningOverlord.settings.dropMineUntilRCL || (this.colony.level > MiningOverlord.settings.dropMineUntilRCL && this.colony.extensions.length < 10);
 		if (this.mode != 'early' && !this.allowDropMining) {
 			if (this.container) {
 				this.harvestPos = this.container.pos;


### PR DESCRIPTION
## Pull request summary
Corner case fix, allow drop mining after room wipe @ RCL > 3
### Description:
<!--- Include a description of the changes in this pull request here --->
when a room with RCL > 3 gets wiped, and after colonization with a single structure up (spawn that is) the drones stand idle and not harvesting, due to allowDropMining flag == false
The proposed fix is to check and allow if RCL>3 and Extentions.length < 10  too

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->
no issue number - 
 this.allowDropMining = this.colony.level < MiningOverlord.settings.dropMineUntilRCL || (this.colony.level > MiningOverlord.settings.dropMineUntilRCL && this.colony.extensions.length < 10);
- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

