### PR TITLE
Adding controller signature error

### DIFF
--- a/src/console/Console.ts
+++ b/src/console/Console.ts
@@ -143,7 +143,9 @@ export class OvermindConsole {
 
 	static setSignature(signature: string | undefined): string | undefined {
 		let sig = signature ? signature : DEFAULT_OVERMIND_SIGNATURE;
-		if (sig.toLowerCase().includes('overmind') || sig.includes(DEFAULT_OVERMIND_SIGNATURE)) {
+		if (sig.length > 100) {
+			throw new Error(`Invalid signature: ${signature}; length is over 100 chars.`);
+		} else if (sig.toLowerCase().includes('overmind') || sig.includes(DEFAULT_OVERMIND_SIGNATURE)) {
 			Memory.settings.signature = sig;
 			return `Controller signature set to ${sig}`;
 		} else {


### PR DESCRIPTION
Tiny commit, just adds an error. There is a bug where rooms get locked trying to set controller sig if it's too long.

It's tested.