### PR TITLE
fix scout stomping code

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
-    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
+    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/src/overlords/scouting/randomWalker.ts
+++ b/src/overlords/scouting/randomWalker.ts
@@ -30,7 +30,7 @@ export class RandomWalkerScoutOverlord extends Overlord {
 		const enemyConstructionSites = scout.room.find(FIND_HOSTILE_CONSTRUCTION_SITES);
 		if (enemyConstructionSites.length > 0 && enemyConstructionSites[0].pos.isWalkable(true)) {
 			scout.goTo(enemyConstructionSites[0].pos);
-			return; //bug fix, must not goToRoom until all hostile constuction sites have been stomped on.
+			return;
 		}
 		// Check if room might be connected to newbie/respawn zone
 		const indestructibleWalls = _.filter(scout.room.walls, wall => wall.hits == undefined);

--- a/src/overlords/scouting/randomWalker.ts
+++ b/src/overlords/scouting/randomWalker.ts
@@ -30,6 +30,7 @@ export class RandomWalkerScoutOverlord extends Overlord {
 		const enemyConstructionSites = scout.room.find(FIND_HOSTILE_CONSTRUCTION_SITES);
 		if (enemyConstructionSites.length > 0) {
 			scout.goTo(enemyConstructionSites[0].pos);
+			return; //bug fix, must not goToRoom until all hostile constuction sites have been stomped on.
 		}
 		// Check if room might be connected to newbie/respawn zone
 		const indestructibleWalls = _.filter(scout.room.walls, wall => wall.hits == undefined);

--- a/src/overlords/scouting/randomWalker.ts
+++ b/src/overlords/scouting/randomWalker.ts
@@ -28,7 +28,7 @@ export class RandomWalkerScoutOverlord extends Overlord {
 	private handleScout(scout: Zerg) {
 		// Stomp on enemy construction sites
 		const enemyConstructionSites = scout.room.find(FIND_HOSTILE_CONSTRUCTION_SITES);
-		if (enemyConstructionSites.length > 0) {
+		if (enemyConstructionSites.length > 0 && enemyConstructionSites[0].pos.isWalkable(true)) {
 			scout.goTo(enemyConstructionSites[0].pos);
 			return; //bug fix, must not goToRoom until all hostile constuction sites have been stomped on.
 		}


### PR DESCRIPTION
## Pull request summary
a fix for scouts not stomping hostile construction sites.
### Description:
<!--- Include a description of the changes in this pull request here --->

### Added:
<!--- Include new features added with this pull request here --->
return;
i.e. finish stomping all cons sites before moving to a new room

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

