### PR TITLE
fix roadPlanner coverage%

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
+    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/src/roomPlanner/RoadPlanner.ts
+++ b/src/roomPlanner/RoadPlanner.ts
@@ -69,6 +69,7 @@ export class RoadPlanner {
 		// Compute coverage for each path
 		for (const destination of this.colony.destinations) {
 			const destName = destination.pos.name;
+			if(!!this.memory.roadLookup[destination.pos.roomName]) //fix, roadConvergence% should only consider rooms in roodLookup instead of all rooms in roadCovergaces
 			if (!this.memory.roadCoverages[destName] || Game.time > this.memory.roadCoverages[destName].exp) {
 				const roadCoverage = this.computeRoadCoverage(storagePos, destination.pos);
 				if (roadCoverage != undefined) {


### PR DESCRIPTION
## Pull request summary
existing roadCoverage calculations takes into account all roadCoverages[] rooms which are being populated by directives.
those rooms can be very far and many of them are not remote/SK rooms.
by doing so, the road convergence % will mostly result in < 75%, which is the threshold for 2:1 transporter body.
the fix will consider rooms in roadLookup instead (which include rm/sk/self-colony rooms only.

use the below in console to check existing roadCoverage:
_.forEach(Memory.colonies,room =>{
  console.log(room.roadPlanner.roadCoverage);
})
### Description:
<!--- Include a description of the changes in this pull request here --->
the below shows the impact on coverage before and after
Room# | BEFORE | AFTER
-- | -- | --
1 | 0.65 | 0.96
2 | 0.29 | 0.96
3 | 0.19 | 0.96
4 | 0.38 | 0.96
5 | 0.41 | 0.96
6 | 0.46 | 0.93
7 | 0.50 | 0.96
8 | 0.40 | 0.96
9 | 0.33 | 0.96
10 | 0.52 | 0.96
11 | 0.51 | 0.96
12 | 0.50 | 0.96
13 | 0.65 | 0.96
14 | 0.50 | 0.96
15 | 0.54 | 0.96
16 | 0.92 | 0.96
17 | 0.82 | 0.96
18 | 0.45 | 0.96
19 | 0.48 | 0.96
20 | 0.60 | 0.88
21 | 0.98 | 0.96
22 | 0.96 | 0.96
23 | 0.41 | 0.96
24 | 0.66 | 0.96
25 | 0.92 | 0.96
26 | 0.00 | 0.96


### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

