### PR TITLE
Fix for Haul flags get removed without hauling complete #73

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
-    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
+    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/src/directives/resource/haul.ts
+++ b/src/directives/resource/haul.ts
@@ -106,7 +106,7 @@ export class DirectiveHaul extends Directive {
 	}
 
 	run(): void {
-		if (totalResources== 0 && this.pos.isVisible) {
+		if (this.totalResources == 0 && this.pos.isVisible) {
 			this.remove();
 		}
 	}

--- a/src/directives/resource/haul.ts
+++ b/src/directives/resource/haul.ts
@@ -106,7 +106,7 @@ export class DirectiveHaul extends Directive {
 	}
 
 	run(): void {
-		if (_.sum(this.store) == 0 && this.pos.isVisible) {
+		if (totalResources== 0 && this.pos.isVisible) {
 			this.remove();
 		}
 	}

--- a/src/directives/resource/haul.ts
+++ b/src/directives/resource/haul.ts
@@ -106,7 +106,7 @@ export class DirectiveHaul extends Directive {
 	}
 
 	run(): void {
-		if (this.totalResources == 0 && this.pos.isVisible) {
+		if (this.totalResources == 0) {
 			this.remove();
 		}
 	}

--- a/src/directives/resource/haul.ts
+++ b/src/directives/resource/haul.ts
@@ -102,7 +102,7 @@ export class DirectiveHaul extends Directive {
 	}
 
 	init(): void {
-		this.alert(`Haul directive active - ${this.totalResources} remaining`);
+		this.alert(`Haul directive active - ${this.totalResources}`);
 	}
 
 	run(): void {

--- a/src/directives/resource/haul.ts
+++ b/src/directives/resource/haul.ts
@@ -102,7 +102,7 @@ export class DirectiveHaul extends Directive {
 	}
 
 	init(): void {
-		this.alert(`Haul directive active`);
+		this.alert(`Haul directive active - ${this.totalResources} remaining`);
 	}
 
 	run(): void {


### PR DESCRIPTION
## Pull request summary
Fix for issue #73 
Hauling flag gets removed before emptying storage/terminal

### Description:
<!--- Include a description of the changes in this pull request here --->

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->
Haul flags get removed without hauling complete #73


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

