### PR TITLE
make stationary scouts from attackController stomp csites

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
-    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
+    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/src/overlords/scouting/stationary.ts
+++ b/src/overlords/scouting/stationary.ts
@@ -24,6 +24,14 @@ export class StationaryScoutOverlord extends Overlord {
 
 	run() {
 		for (const scout of this.scouts) {
+			if(this.pos.roomName == scout.room.name){
+				const enemyConstructionSites = scout.room.find(FIND_HOSTILE_CONSTRUCTION_SITES);
+				if (enemyConstructionSites.length > 0 && enemyConstructionSites[0].pos.isWalkable(true)) {
+					scout.goTo(enemyConstructionSites[0].pos);
+					return;
+				}
+			}
+
 			if (!(scout.pos.inRangeTo(this.pos, 3) && !scout.pos.isEdge)) {
 				scout.goTo(this.pos, {range: 3});
 			}

--- a/src/overlords/scouting/stationary.ts
+++ b/src/overlords/scouting/stationary.ts
@@ -19,12 +19,13 @@ export class StationaryScoutOverlord extends Overlord {
 	}
 
 	init() {
-		this.wishlist(1, Setups.scout);
+		const amount = (this.pos.isVisible)? 0:1;
+		this.wishlist(amount, Setups.scout);
 	}
 
 	run() {
 		for (const scout of this.scouts) {
-			if(this.pos.roomName == scout.room.name){
+			if(this.pos.roomName == scout.room.name) {
 				const enemyConstructionSites = scout.room.find(FIND_HOSTILE_CONSTRUCTION_SITES);
 				if (enemyConstructionSites.length > 0 && enemyConstructionSites[0].pos.isWalkable(true)) {
 					scout.goTo(enemyConstructionSites[0].pos);


### PR DESCRIPTION
## Pull request summary
make stationary scouts from attackController stomp csites instead of staying idle

### Description:
<!--- Include a description of the changes in this pull request here --->

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

