### PR TITLE
Nuke response: Reduce coverage of reinforcement

### DIFF
--- a/src/overlords/core/worker.ts
+++ b/src/overlords/core/worker.ts
@@ -133,7 +133,7 @@ export class WorkerOverlord extends Overlord {
 		for (const nuke of rampart.pos.lookFor(LOOK_NUKES)) {
 			neededHits += 10e6;
 		}
-		for (const nuke of rampart.pos.findInRange(FIND_NUKES, 3)) {
+		for (const nuke of rampart.pos.findInRange(FIND_NUKES, 2)) {
 			if (nuke.pos != rampart.pos) {
 				neededHits += 5e6;
 			}

--- a/src/overlords/core/worker.ts
+++ b/src/overlords/core/worker.ts
@@ -13,6 +13,7 @@ import {minBy} from '../../utilities/utils';
 import {Zerg} from '../../zerg/Zerg';
 import {Overlord, ZergOptions} from '../Overlord';
 import {DirectiveNukeResponse} from "../../directives/situational/nukeResponse";
+import {Visualizer} from "../../visuals/Visualizer";
 
 /**
  * Spawns general-purpose workers, which maintain a colony, performing actions such as building, repairing, fortifying,
@@ -109,8 +110,10 @@ export class WorkerOverlord extends Overlord {
 		if (this.room.find(FIND_NUKES).length > 0) {
 			for (const rampart of this.colony.room.ramparts) {
 				const neededHits = this.neededRampartHits(rampart);
-				if (rampart.hits < neededHits && DirectiveNukeResponse.shouldReinforceLocation(rampart.pos)) {
+				if (rampart.hits < neededHits && rampart.pos.findInRange(FIND_NUKES, 3)
+					&& DirectiveNukeResponse.shouldReinforceLocation(rampart.pos)) {
 					this.nukeDefenseRamparts.push(rampart);
+					Visualizer.marker(rampart.pos, {color: 'gold'});
 					this.nukeDefenseHitsRemaining[rampart.id] = neededHits - rampart.hits;
 				}
 			}

--- a/src/overlords/core/worker.ts
+++ b/src/overlords/core/worker.ts
@@ -110,7 +110,7 @@ export class WorkerOverlord extends Overlord {
 		if (this.room.find(FIND_NUKES).length > 0) {
 			for (const rampart of this.colony.room.ramparts) {
 				const neededHits = this.neededRampartHits(rampart);
-				if (rampart.hits < neededHits && rampart.pos.findInRange(FIND_NUKES, 3)
+				if (rampart.hits < neededHits && rampart.pos.findInRange(FIND_NUKES, 3).length > 0
 					&& DirectiveNukeResponse.shouldReinforceLocation(rampart.pos)) {
 					this.nukeDefenseRamparts.push(rampart);
 					Visualizer.marker(rampart.pos, {color: 'gold'});

--- a/src/overlords/core/worker.ts
+++ b/src/overlords/core/worker.ts
@@ -12,6 +12,7 @@ import {Cartographer, ROOMTYPE_CONTROLLER} from '../../utilities/Cartographer';
 import {minBy} from '../../utilities/utils';
 import {Zerg} from '../../zerg/Zerg';
 import {Overlord, ZergOptions} from '../Overlord';
+import {DirectiveNukeResponse} from "../../directives/situational/nukeResponse";
 
 /**
  * Spawns general-purpose workers, which maintain a colony, performing actions such as building, repairing, fortifying,
@@ -108,7 +109,7 @@ export class WorkerOverlord extends Overlord {
 		if (this.room.find(FIND_NUKES).length > 0) {
 			for (const rampart of this.colony.room.ramparts) {
 				const neededHits = this.neededRampartHits(rampart);
-				if (rampart.hits < neededHits) {
+				if (rampart.hits < neededHits && DirectiveNukeResponse.shouldReinforceLocation(rampart.pos)) {
 					this.nukeDefenseRamparts.push(rampart);
 					this.nukeDefenseHitsRemaining[rampart.id] = neededHits - rampart.hits;
 				}


### PR DESCRIPTION
## Pull request summary

### Description:
Adds a consistent function to select what to reinforce.
It's still reinforcing ramparts outside of nuke area, want to add a special 35 work 5 carry 10 move boosted work worker for the reinforcement.

### Added:
Only reinforce needed structures now, no more roads. Should reduce eco damage from nukes.

- [X] Changes are backward-compatible OR version migration code is included
- [X] Codebase compiles with current `tsconfig` configuration
- [X] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

