### PR TITLE
Novice protection: detect novice and respawn zones

### DIFF
--- a/src/declarations/memory.d.ts
+++ b/src/declarations/memory.d.ts
@@ -30,8 +30,8 @@ interface Memory {
 	haltTick?: number;
 	combatPlanner: any;
 	reinforcementLearning?: any;
-
 	zoneRooms: { [roomName: string]: { [type: string]: number} };
+
 	[otherProperty: string]: any;
 }
 

--- a/src/declarations/memory.d.ts
+++ b/src/declarations/memory.d.ts
@@ -31,6 +31,7 @@ interface Memory {
 	combatPlanner: any;
 	reinforcementLearning?: any;
 
+	zoneRooms: { [roomName: string]: { [type: string]: number} };
 	[otherProperty: string]: any;
 }
 

--- a/src/intel/RoomIntel.ts
+++ b/src/intel/RoomIntel.ts
@@ -7,6 +7,7 @@ import {ExpansionEvaluator} from '../strategy/ExpansionEvaluator';
 import {getCacheExpiration, irregularExponentialMovingAverage} from '../utilities/utils';
 import {Zerg} from '../zerg/Zerg';
 import {MY_USERNAME} from '../~settings';
+import {Segmenter} from "../memory/Segmenter";
 
 const RECACHE_TIME = 2500;
 const OWNED_RECACHE_TIME = 1000;
@@ -351,6 +352,16 @@ export class RoomIntel {
 		return 0;
 	}
 
+	static requestZoneData() {
+		const checkOnTick = 12;
+		if (Game.time % 30 == checkOnTick - 2) {
+			Segmenter.requestForeignSegment('LOAN', 96);
+		} else if (Game.time % 30 == checkOnTick - 1) {
+			const loanData = Segmenter.getForeignSegment();
+			console.log(`\n \n \n \n Loan Data is: ${loanData} \n \n \n \n `);
+		}
+	}
+
 
 	static run(): void {
 		let alreadyComputedScore = false;
@@ -360,6 +371,7 @@ export class RoomIntel {
 
 			this.markVisible(room);
 			this.recordSafety(room);
+			this.requestZoneData();
 
 			// Track invasion data, harvesting, and casualties for all colony rooms and outposts
 			if (Overmind.colonyMap[room.name]) { // if it is an owned or outpost room

--- a/src/intel/RoomIntel.ts
+++ b/src/intel/RoomIntel.ts
@@ -8,6 +8,7 @@ import {getCacheExpiration, irregularExponentialMovingAverage} from '../utilitie
 import {Zerg} from '../zerg/Zerg';
 import {MY_USERNAME} from '../~settings';
 import {Segmenter} from "../memory/Segmenter";
+import {log} from "../console/log";
 
 const RECACHE_TIME = 2500;
 const OWNED_RECACHE_TIME = 1000;
@@ -353,15 +354,15 @@ export class RoomIntel {
 	}
 
 	static requestZoneData() {
-		const checkOnTick = 4;
-		if (Game.time % 10 == checkOnTick - 2) {
+		const checkOnTick = 123;
+		if (Game.time % 1000 == checkOnTick - 2) {
 			Segmenter.requestForeignSegment('LeagueOfAutomatedNations', 96);
-		} else if (Game.time % 10 == checkOnTick - 1 || Game.time % 10 == checkOnTick) {
+		} else if (Game.time % 1000 == checkOnTick - 1 ) {
 			const loanData = Segmenter.getForeignSegment();
 			if (loanData) {
-				console.log(`\n \n \n \n Loan Data is: ${JSON.stringify(loanData)} \n \n \n \n `);
+				Memory.zoneRooms = loanData;
 			} else {
-				console.log('Empty loan data');
+				log.error('Empty LOAN data');
 			}
 		}
 	}

--- a/src/intel/RoomIntel.ts
+++ b/src/intel/RoomIntel.ts
@@ -353,25 +353,34 @@ export class RoomIntel {
 	}
 
 	static requestZoneData() {
-		const checkOnTick = 12;
-		if (Game.time % 30 == checkOnTick - 2) {
-			Segmenter.requestForeignSegment('LOAN', 96);
-		} else if (Game.time % 30 == checkOnTick - 1) {
+		const checkOnTick = 4;
+		if (Game.time % 10 == checkOnTick - 2) {
+			Segmenter.requestForeignSegment('LeagueOfAutomatedNations', 96);
+		} else if (Game.time % 10 == checkOnTick - 1 || Game.time % 10 == checkOnTick) {
 			const loanData = Segmenter.getForeignSegment();
-			console.log(`\n \n \n \n Loan Data is: ${loanData} \n \n \n \n `);
+			if (loanData) {
+				console.log(`\n \n \n \n Loan Data is: ${JSON.stringify(loanData)} \n \n \n \n `);
+			} else {
+				console.log('Empty loan data');
+			}
 		}
 	}
 
 
 	static run(): void {
 		let alreadyComputedScore = false;
+		this.requestZoneData();
+
 		for (const name in Game.rooms) {
 
 			const room: Room = Game.rooms[name];
 
+			if (Memory.zoneRooms && _.keys(Memory.zoneRooms).indexOf(name) != -1) {
+				console.log(`Room ${name} found in zone! ${Memory.zoneRooms[name]}`);
+			}
+
 			this.markVisible(room);
 			this.recordSafety(room);
-			this.requestZoneData();
 
 			// Track invasion data, harvesting, and casualties for all colony rooms and outposts
 			if (Overmind.colonyMap[room.name]) { // if it is an owned or outpost room

--- a/src/intel/RoomIntel.ts
+++ b/src/intel/RoomIntel.ts
@@ -376,10 +376,6 @@ export class RoomIntel {
 
 			const room: Room = Game.rooms[name];
 
-			if (Memory.zoneRooms && _.keys(Memory.zoneRooms).indexOf(name) != -1) {
-				console.log(`Room ${name} found in zone! ${Memory.zoneRooms[name]}`);
-			}
-
 			this.markVisible(room);
 			this.recordSafety(room);
 

--- a/src/utilities/Cartographer.ts
+++ b/src/utilities/Cartographer.ts
@@ -1,4 +1,5 @@
 import {profile} from '../profiler/decorator';
+import {log} from "../console/log";
 
 export const ROOMTYPE_SOURCEKEEPER = 'SK';
 export const ROOMTYPE_CORE = 'CORE';
@@ -212,6 +213,26 @@ export class Cartographer {
 			xDir: xDir,
 			yDir: yDir,
 		};
+	}
+
+	static isNoviceRoom(roomName: string): boolean {
+		if (Memory.zoneRooms) {
+			const roomInfo = Memory.zoneRooms[roomName];
+			return roomInfo && !!roomInfo['novice'];
+		} else {
+			log.alert(`Checking novice room before segment is set in ${roomName}!`);
+			return false;
+		}
+	}
+
+	static isRespawnRoom(roomName: string): boolean {
+		if (Memory.zoneRooms) {
+			const roomInfo = Memory.zoneRooms[roomName];
+			return roomInfo && !!roomInfo['respawnArea'];
+		} else {
+			log.alert(`Checking respawn room before segment is set in ${roomName}!`);
+			return false;
+		}
 	}
 
 }

--- a/src/utilities/Cartographer.ts
+++ b/src/utilities/Cartographer.ts
@@ -218,7 +218,7 @@ export class Cartographer {
 	static isNoviceRoom(roomName: string): boolean {
 		if (Memory.zoneRooms) {
 			const roomInfo = Memory.zoneRooms[roomName];
-			return roomInfo && !!roomInfo['novice'];
+			return !!roomInfo && !!roomInfo['novice'];
 		} else {
 			log.alert(`Checking novice room before segment is set in ${roomName}!`);
 			return false;
@@ -228,7 +228,7 @@ export class Cartographer {
 	static isRespawnRoom(roomName: string): boolean {
 		if (Memory.zoneRooms) {
 			const roomInfo = Memory.zoneRooms[roomName];
-			return roomInfo && !!roomInfo['respawnArea'];
+			return !!roomInfo && !!roomInfo['respawnArea'];
 		} else {
 			log.alert(`Checking respawn room before segment is set in ${roomName}!`);
 			return false;


### PR DESCRIPTION
## Pull request summary

### Description:
Tracking novice and respawn zones from LOAN

### Added:
Stores novice/respawn rooms in memory with utils to access both

## Testing checklist:

Tested in prod with rooms selected from https://screepspl.us/data/shard2.novice.json
```console.log(`Room is a respawn room: ${'W21S33'} checking ${Cartographer.isRespawnRoom('W21S33')}`);
console.log(`Room is a respawn room: ${'W11S13'} checking ${Cartographer.isRespawnRoom('W11S13')}`);```
```[1:30:01 PM][shard2]Room is a respawn room: W21S33 checking true```
```[1:30:01 PM][shard2]Room is a respawn room: W11S13 checking false```
