### PR TITLE
Kite ranged

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
+    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/src/zerg/CombatZerg.ts
+++ b/src/zerg/CombatZerg.ts
@@ -162,7 +162,7 @@ export class CombatZerg extends Zerg {
 	 */
 	autoRanged(possibleTargets = this.room.hostiles, allowMassAttack = true) {
 		let nearbyHostiles = _.filter(this.room.dangerousHostiles, c => this.pos.inRangeToXY(c.pos.x, c.pos.y, 2));
-		if(nearbyHostiles.length > 2 && !this.inRampart) {
+		if(nearbyHostiles.length > 1 && !this.inRampart) {
 			this.rangedMassAttack();
 			return this.kite();
 		} else if(nearbyHostiles.length == 1 && !this.inRampart) {

--- a/src/zerg/CombatZerg.ts
+++ b/src/zerg/CombatZerg.ts
@@ -162,7 +162,7 @@ export class CombatZerg extends Zerg {
 	 */
 	autoRanged(possibleTargets = this.room.hostiles, allowMassAttack = true) {
 		let nearbyHostiles = _.filter(this.room.dangerousHostiles, c => this.pos.inRangeToXY(c.pos.x, c.pos.y, 2));
-		if(nearbyHostiles.length){
+		if(nearbyHostiles.length && !this.inRampart) {
 			return this.kite();
 		}
 		const target = CombatTargeting.findBestCreepTargetInRange(this, 3, possibleTargets)

--- a/src/zerg/CombatZerg.ts
+++ b/src/zerg/CombatZerg.ts
@@ -161,6 +161,10 @@ export class CombatZerg extends Zerg {
 	 * Automatically ranged-attack the best creep in range
 	 */
 	autoRanged(possibleTargets = this.room.hostiles, allowMassAttack = true) {
+		let nearbyHostiles = _.filter(this.room.dangerousHostiles, c => this.pos.inRangeToXY(c.pos.x, c.pos.y, 2));
+		if(nearbyHostiles.length){
+			return this.kite();
+		}
 		const target = CombatTargeting.findBestCreepTargetInRange(this, 3, possibleTargets)
 					   || CombatTargeting.findBestStructureTargetInRange(this, 3);
 		this.debug(`Ranged target: ${target}`);

--- a/src/zerg/CombatZerg.ts
+++ b/src/zerg/CombatZerg.ts
@@ -162,10 +162,15 @@ export class CombatZerg extends Zerg {
 	 */
 	autoRanged(possibleTargets = this.room.hostiles, allowMassAttack = true) {
 		let nearbyHostiles = _.filter(this.room.dangerousHostiles, c => this.pos.inRangeToXY(c.pos.x, c.pos.y, 2));
-		if(nearbyHostiles.length && !this.inRampart) {
+		if(nearbyHostiles.length > 2 && !this.inRampart) {
 			this.rangedMassAttack();
 			return this.kite();
-		}
+		} else if(nearbyHostiles.length == 1 && !this.inRampart) {
+			if(!!nearbyHostiles[0]){
+				this.rangedAttack(nearbyHostiles[0]);
+			}
+			return this.kite();
+		} 
 		const target = CombatTargeting.findBestCreepTargetInRange(this, 3, possibleTargets)
 					   || CombatTargeting.findBestStructureTargetInRange(this, 3);
 		this.debug(`Ranged target: ${target}`);

--- a/src/zerg/CombatZerg.ts
+++ b/src/zerg/CombatZerg.ts
@@ -163,6 +163,7 @@ export class CombatZerg extends Zerg {
 	autoRanged(possibleTargets = this.room.hostiles, allowMassAttack = true) {
 		let nearbyHostiles = _.filter(this.room.dangerousHostiles, c => this.pos.inRangeToXY(c.pos.x, c.pos.y, 2));
 		if(nearbyHostiles.length && !this.inRampart) {
+			this.rangedMassAttack();
 			return this.kite();
 		}
 		const target = CombatTargeting.findBestCreepTargetInRange(this, 3, possibleTargets)


### PR DESCRIPTION
## Pull request summary
Hydralisks are suicidal!, boosted or not, they charge in numbers and get slaughtered!
this minor change will keep ranged_attack creep at distance of > 2 and kite around.
giving it a chance to heal/attack and live longer. in addition to holding into ramp position.

Davaned and I have noticed a positive impact when defending rooms using this update.

### Description:
<!--- Include a description of the changes in this pull request here --->

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [ ] Changes are backward-compatible OR version migration code is included
- [ ] Codebase compiles with current `tsconfig` configuration
- [ ] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

