### PR TITLE
Outpost and Ranged defense fighting creeps regroup when hostiles == 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
-    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.1.2",
     "columnify": "1.5.4",
+    "lint": "^0.7.0",
     "onnxjs": "^0.1.6",
     "source-map": "0.7.3"
   }

--- a/src/overlords/defense/outpostDefense.ts
+++ b/src/overlords/defense/outpostDefense.ts
@@ -27,6 +27,9 @@ export class OutpostDefenseOverlord extends CombatOverlord {
 
 	private handleCombat(zerg: CombatZerg): void {
 		if (this.room && this.room.hostiles.length == 0) {
+			if (zerg.pos.getRangeTo(this.directive.pos) > 4) {
+                zerg.goTo(this.directive.pos);
+            }
 			zerg.doMedicActions(this.room.name);
 		} else {
 			zerg.autoSkirmish(this.pos.roomName);

--- a/src/overlords/defense/rangedDefense.ts
+++ b/src/overlords/defense/rangedDefense.ts
@@ -33,12 +33,15 @@ export class RangedDefenseOverlord extends CombatOverlord {
 	}
 
 	private handleDefender(hydralisk: CombatZerg): void {
-		if (this.room.hostiles.length > 0) {
-			hydralisk.autoCombat(this.room.name);
-		} else {
-			hydralisk.doMedicActions(this.room.name);
-		}
-	}
+	    if (this.room.hostiles.length > 0) {
+            hydralisk.autoCombat(this.room.name);
+        } else {
+            if (hydralisk.pos.getRangeTo(this.directive.pos) > 4) {
+                hydralisk.goTo(this.directive.pos);
+            }
+            hydralisk.doMedicActions(this.room.name);
+        }
+    }
 
 	private computeNeededHydraliskAmount(setup: CreepSetup, boostMultiplier: number): number {
 		const healAmount = CombatIntel.maxHealingByCreeps(this.room.hostiles);


### PR DESCRIPTION
## Pull request summary
when skirmish is over, the fighting creeps end up scattered all over the room, specially when defending own room with many spawned creeps.
this PR will regroup the creeps of outpost and ranged defense directive around the directive flag.

this will increase their survival for when the next wave of enemy attacks, as they will all charge as a group/team

### Description:
<!--- Include a description of the changes in this pull request here --->

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

