### PR TITLE
Update npcDefense.ts

### DIFF
--- a/src/overlords/defense/npcDefense.ts
+++ b/src/overlords/defense/npcDefense.ts
@@ -78,7 +78,7 @@ export class DefenseNPCOverlord extends Overlord {
 	}
 
 	init() {
-		const amount = this.room && (this.room.invaders.length > 0 || RoomIntel.isInvasionLikely(this.room)) ? 1 : 0;
+		const amount = this.room && (this.room.invaders.length > 0 || this.room.invaderCore || RoomIntel.isInvasionLikely(this.room)) ? 1 : 0;
 		this.wishlist(amount, CombatSetups.broodlings.default, {reassignIdle: true});
 	}
 


### PR DESCRIPTION
Guard Directive automatically gets placed when the invader core appears, but is a structure so isn't picked up by `this.room.invaders` so the number of requested guards will always be zero, and so the Invader Cores won't get attacked.

## Pull request summary

### Description:
Makes sure to actually assign a guard for invader cores

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- Updated "When Should I request a guard" check

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [ ] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *PTR* server OR changes are trivial (e.g. typos)

