### PR TITLE
lol fixed playerhostiles

### DIFF
--- a/src/declarations/prototypes.d.ts
+++ b/src/declarations/prototypes.d.ts
@@ -7,7 +7,7 @@ interface Creep {
 	inRampart: boolean;
 	approxMoveSpeed: number;
 	bodypartCounts: { [bodypart in BodyPartConstant]: number };
-	isHuman: true;
+	isPlayer: true;
 }
 
 interface PowerCreep {

--- a/src/prototypes/Room.ts
+++ b/src/prototypes/Room.ts
@@ -114,7 +114,7 @@ Object.defineProperty(Room.prototype, 'sourceKeepers', {
 Object.defineProperty(Room.prototype, 'playerHostiles', {
 	get() {
 		if (!this._playerHostiles) {
-			this._playerHostiles = _.filter(this.hostiles, (creep: Creep) => creep.isHuman);
+			this._playerHostiles = _.filter(this.hostiles, (creep: Creep) => creep.isPlayer);
 		}
 		return this._playerHostiles;
 	},


### PR DESCRIPTION
/facepalm

## Pull request summary

### Description:
Fixes what appears to be a mistype of isPlayer vs isHuman in the prototypes for creeps / room tracking.

### Fixed:
Defenses / safe mode wasn't operating correctly due to not seeing hostile player entities.

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x ] Changes are backward-compatible OR version migration code is included
- [x ] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

