### PR TITLE
cherry pick: 0 = false, check for key exists. stop moving managers

### DIFF
--- a/src/movement/Movement.ts
+++ b/src/movement/Movement.ts
@@ -463,7 +463,7 @@ export class Movement {
 			if (isPowerZerg(creep)) {
 				return MovePriorities.powerCreep;
 			} else {
-				return MovePriorities[creep.memory.role] || MovePriorities.default;
+				return (creep.memory.role in MovePriorities) ? MovePriorities[creep.memory.role] : MovePriorities.default;
 			}
 		}
 	}


### PR DESCRIPTION
## Pull request summary

### Description:
Manager was getting pushed, debuged to this logic bug that 0 fails the test intended to check if the element exists. Replaced with equivalent test logic.

### Fixed:
MovePush check incorrectly treating manager 0 value as nonexistent and taking default 10 causing unintended push.

## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on PUBLIC server OR changes are trivial (e.g. typos)

