### PR TITLE
Nuke response

### DIFF
--- a/src/Overseer.ts
+++ b/src/Overseer.ts
@@ -314,7 +314,7 @@ export class Overseer implements IOverseer {
 		// Place nuke response directive if there is a nuke present in colony room
 		if (colony.room && colony.level >= DirectiveNukeResponse.requiredRCL) {
 			for (const nuke of colony.room.find(FIND_NUKES)) {
-				DirectiveNukeResponse.createIfNotPresent(nuke.pos, 'pos');
+				DirectiveNukeResponse.createIfNotPresent(colony.controller.pos, 'room');
 			}
 		}
 	}


### PR DESCRIPTION
## Pull request summary
Code I'm running modified to handle nuke responses "better".

### Description:
Nuke Responses already handle multiple nukes, so consolidate. Also don't just true up fortifications from highest to lowest priority as they could be woefully behind. First upgrade them to minimum survival value + critical barrier value, then fortify them as a subset using the normal proportional rules.

This was a pretty quick throw together, so I expect there will be things to clean up.

## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on PUBLIC server OR changes are trivial (e.g. typos)

