### PR TITLE
Fix vacatePos & Fix autoRun() 

### DIFF
--- a/src/movement/Movement.ts
+++ b/src/movement/Movement.ts
@@ -562,7 +562,6 @@ export class Movement {
 	}
 
 
-	// TODO: this is bugged somewhere
 	/**
 	 * Recursively moves creeps out of the way of a position to make room for something, such as a spawning creep.
 	 * If suicide is specified and there is no series of move commands that can move a block of creeps out of the way,

--- a/src/overlords/CombatOverlord.ts
+++ b/src/overlords/CombatOverlord.ts
@@ -42,7 +42,7 @@ export abstract class CombatOverlord extends Overlord {
 	autoRun(roleCreeps: CombatZerg[], creepHandler: (creep: CombatZerg) => void) {
 		for (const creep of roleCreeps) {
 			if (creep.spawning) {
-				return;
+				continue;
 			}
 			if (creep.hasValidTask) {
 				creep.run();

--- a/src/zerg/AnyZerg.ts
+++ b/src/zerg/AnyZerg.ts
@@ -209,7 +209,7 @@ export abstract class AnyZerg {
 	}
 
 	move(direction: DirectionConstant, force = false) {
-		if (!this.blockMovement && !force) {
+		if (!this.blockMovement || force) {
 			const result = this.creep.move(direction);
 			if (result == OK) {
 				if (!this.actionLog.move) this.actionLog.move = true;


### PR DESCRIPTION
## Bugfixes

### Description:
There was a logic error in the AnyZerg move() method, causing the issue in Movement.vacatePos().
The method vacatePos() sets creep.blockMovement to true, but is meant to override it with force: true. The check in AnyZerg said "!this.blockMovement && !force" Therefore this method was not working, and the creep not moving. Swapped it to "!this.blockMovement || force".

Also fixed an issue where Zergs of a role would stop working if one of their kind was spawning, there was a return instead of an continue, aborting any Zerg actions after it.

### Fixed:

- Movement.vacatePos() (to clear spawn area) (fixes #50) 
- Zergs of a role would stop working if one of their kind was spawning


## Testing checklist:

- [X] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [X] Tested changes on *PUBLIC* server OR changes are trivial (e.g. typos)

