### PR TITLE
Bug fix01 manager.ts

### DIFF
--- a/src/overlords/core/manager.ts
+++ b/src/overlords/core/manager.ts
@@ -374,7 +374,7 @@ export class CommandCenterOverlord extends Overlord {
 		// Look for tombstones at position
 		const tombstones = manager.pos.lookFor(LOOK_TOMBSTONES);
 		const tombstone = _.first(tombstones);
-		if (tombstone) {
+		if (tombstone && _.sum(tombstone.store) > 0) {
 			manager.task = Tasks.chain([Tasks.withdrawAll(tombstone), Tasks.transferAll(this.commandCenter.storage)]);
 			return true;
 		}


### PR DESCRIPTION
there is a bug in manager.ts
basically, the manager gets stuck on top of the tombstone of the previous dead manager trying to pickup its dropped resources without checking if it has resources left in the first place.
a simple fix would be to check _.sum(tombstone.store) > 0

currently, the manager would stay idle (stuck) until the tombstone decays.


