### PR TITLE
Low RCl improvements

### DIFF
--- a/src/Colony.ts
+++ b/src/Colony.ts
@@ -202,8 +202,8 @@ export class Colony {
 
 	static settings = {
 		remoteSourcesByLevel: {
-			1: 1,
-			2: 2,
+			1: 2,
+			2: 3,
 			3: 3,
 			4: 4,
 			5: 5,

--- a/src/console/globals.ts
+++ b/src/console/globals.ts
@@ -1,5 +1,5 @@
 declare const __VERSION__: string;
-global.__VERSION__ = '0.5.2';
+global.__VERSION__ = '0.6.0';
 
 declare function deref(ref: string): RoomObject | null;
 

--- a/src/creepSetups/setups.ts
+++ b/src/creepSetups/setups.ts
@@ -89,10 +89,20 @@ export const Setups = {
 		}
 	},
 
-	filler: new CreepSetup(Roles.filler, {
-		pattern  : [CARRY, CARRY, MOVE],
-		sizeLimit: 1,
-	}),
+	fillers: {
+		first: new CreepSetup(Roles.filler, {
+			pattern  : [CARRY, CARRY, MOVE],
+			sizeLimit: 1,
+		}),
+		second: new CreepSetup(Roles.filler, {
+			pattern  : [CARRY, MOVE],
+			sizeLimit: 3,
+		}),
+		third: new CreepSetup(Roles.filler, {
+			pattern  : [CARRY, MOVE],
+			sizeLimit: 6,
+		}),
+	},
 
 	infestors: {
 

--- a/src/directives/situational/bootstrap.ts
+++ b/src/directives/situational/bootstrap.ts
@@ -1,4 +1,4 @@
-import {Colony} from '../../Colony';
+import {Colony, ColonyStage} from '../../Colony';
 import {log} from '../../console/log';
 import {Roles} from '../../creepSetups/setups';
 import {BootstrappingOverlord} from '../../overlords/situational/bootstrap';
@@ -57,8 +57,13 @@ export class DirectiveBootstrap extends Directive {
 			log.alert(`Colony ${this.room.print} has recovered from crash; removing bootstrap directive.`);
 			// Suicide any fillers so they don't get in the way
 			const overlord = this.overlords.bootstrap as BootstrappingOverlord;
+			const queenOverlord = this.colony.hatchery && this.colony.hatchery.overlord;
 			for (const filler of overlord.fillers) {
-				filler.suicide();
+				if (queenOverlord && this.colony.stage == ColonyStage.Larva) {
+					filler.reassign(queenOverlord, Roles.queen, false);
+				} else {
+					filler.suicide();
+				}
 			}
 			// Remove the directive
 			this.remove();

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,9 @@ function onGlobalReset(): void {
 	Mem.format();
 	OvermindConsole.init();
 	VersionMigration.run();
+	if (!Memory.stats.persistent) {
+		Memory.stats.persistent = {};
+	}
 	Memory.stats.persistent.lastGlobalReset = Game.time;
 	OvermindConsole.printUpdateMessage();
 	// Update the master ledger of valid checksums

--- a/src/overlords/core/queen.ts
+++ b/src/overlords/core/queen.ts
@@ -37,7 +37,7 @@ export class QueenOverlord extends Overlord {
 	}
 
 	init() {
-		const amount = 1;
+		const amount = this.hatchery.battery ? 2 : 3;
 		const prespawn = this.hatchery.spawns.length <= 1 ? 100 : DEFAULT_PRESPAWN;
 		this.wishlist(amount, this.queenSetup, {prespawn: prespawn});
 	}

--- a/src/overlords/core/queen_bunker.ts
+++ b/src/overlords/core/queen_bunker.ts
@@ -112,7 +112,7 @@ export class BunkerQueenOverlord extends Overlord {
 			}
 		}
 		// const amount = this.colony.spawns.length > 1 ? 2 : 1;
-		const amount = this.colony.room.energyCapacityAvailable > 2000 ? 2 : 1;
+		const amount = this.colony.room.energyCapacityAvailable > 1300 ? 2 : 1;
 		this.wishlist(amount, this.queenSetup);
 	}
 

--- a/src/overlords/core/transporter.ts
+++ b/src/overlords/core/transporter.ts
@@ -68,7 +68,10 @@ export class TransportOverlord extends Overlord {
 
 		const transportPowerEach = setup.getBodyPotential(CARRY, this.colony);
 		const neededTransportPower = this.neededTransportPower();
-		const numTransporters = Math.ceil(neededTransportPower / transportPowerEach + 0.1); // div by zero error
+		let numTransporters = Math.ceil(neededTransportPower / transportPowerEach + 0.1); // div by zero error
+		if (neededTransportPower === 0) {
+			numTransporters = 0;
+		}
 
 		if (this.transporters.length == 0) {
 			this.wishlist(numTransporters, setup, {priority: OverlordPriority.ownedRoom.firstTransport});

--- a/src/overlords/core/upgrader.ts
+++ b/src/overlords/core/upgrader.ts
@@ -47,6 +47,8 @@ export class UpgradingOverlord extends Overlord {
 				const upgradersNeeded = Math.ceil(this.upgradeSite.upgradePowerNeeded / upgradePowerEach);
 				this.wishlist(upgradersNeeded, setup);
 			}
+		} else if (this.colony.level === 3) {
+			this.wishlist(1, Setups.upgraders.default);
 		}
 	}
 

--- a/src/overlords/defense/npcDefense.ts
+++ b/src/overlords/defense/npcDefense.ts
@@ -1,3 +1,4 @@
+import {ColonyStage} from '../../Colony';
 import {CombatSetups, Roles} from '../../creepSetups/setups';
 import {DirectiveGuard} from '../../directives/defense/guard';
 import {DirectiveHaul} from '../../directives/resource/haul';
@@ -16,10 +17,14 @@ export class DefenseNPCOverlord extends Overlord {
 
 	guards: CombatZerg[];
 
-	static requiredRCL = 3;
+	static requiredRCL = 4;
+	invaderCore: boolean;
 
 	constructor(directive: DirectiveGuard, priority = OverlordPriority.outpostDefense.guard) {
 		super(directive, 'guard', priority);
+		if (directive.memory.invaderCore) {
+			this.invaderCore = true;
+		}
 		this.guards = this.combatZerg(Roles.guardMelee);
 	}
 
@@ -78,7 +83,10 @@ export class DefenseNPCOverlord extends Overlord {
 	}
 
 	init() {
-		const amount = this.room && (this.room.invaders.length > 0 || RoomIntel.isInvasionLikely(this.room)) ? 1 : 0;
+		let amount = 0;
+		if (this.invaderCore || !this.room || (this.room.invaders.length > 0 || RoomIntel.isInvasionLikely(this.room))) {
+			amount = 1;
+		}
 		this.wishlist(amount, CombatSetups.broodlings.default, {reassignIdle: true});
 	}
 

--- a/src/overlords/situational/bootstrap.ts
+++ b/src/overlords/situational/bootstrap.ts
@@ -135,7 +135,7 @@ export class BootstrappingOverlord extends Overlord {
 				const firstOverlord = miningOverlords[0];
 				// first
 				if (this.colony.hatchery) {
-					let setup = Setups.drones.miners.first;
+					let setup = Setups.drones.miners.default;
 					if (this.colony.controller.level > 2) {
 						setup = Setups.drones.miners.emergency;
 					}

--- a/src/tasks/instances/recharge.ts
+++ b/src/tasks/instances/recharge.ts
@@ -1,3 +1,4 @@
+import {Colony} from '../../Colony';
 import {log} from '../../console/log';
 import {isResource} from '../../declarations/typeGuards';
 import {profile} from '../../profiler/decorator';
@@ -65,8 +66,15 @@ export class TaskRecharge extends Task {
 			// workers shouldn't harvest; let drones do it (disabling this check can destabilize early economy)
 			const canHarvest = creep.getActiveBodyparts(WORK) > 0 && creep.roleName != 'worker';
 			if (canHarvest) {
+
+				const colony: Colony | undefined = Overmind.colonies[creep.room.name];
+				let potentialSources: Source[] = creep.room.sources;
+				if (colony) {
+					potentialSources = colony.sources;
+				}
+
 				// Harvest from a source if there is no recharge target available
-				const availableSources = _.filter(creep.room.sources, function(source) {
+				const availableSources = _.filter(potentialSources, function(source) {
 					const filledSource = source.energy > 0 || source.ticksToRegeneration < 20;
 					// Only harvest from sources which aren't surrounded by creeps excluding yourself
 					const isSurrounded = source.pos.availableNeighbors(false).length == 0;

--- a/src/versionMigration/migrator.ts
+++ b/src/versionMigration/migrator.ts
@@ -413,8 +413,10 @@ export class VersionMigration {
 		delete Memory.zoneRooms;
 		Memory.roomIntel = {}; // reset this
 
-		delete Memory.stats.persistent.terminalNetwork.transfers;
-		delete Memory.stats.persistent.terminalNetwork.costs;
+		if (Memory.stats.persistent) {
+			delete Memory.stats.persistent.terminalNetwork.transfers;
+			delete Memory.stats.persistent.terminalNetwork.costs;
+		}
 
 		const mem = Memory as any;
 

--- a/src/visuals/Visualizer.ts
+++ b/src/visuals/Visualizer.ts
@@ -50,6 +50,14 @@ export class Visualizer {
 		return new RoomVisual(pos.roomName).animatedPosition(pos.x, pos.y, opts);
 	}
 
+	static annotate(text: string, pos: { x: number, y: number, roomName?: string }, roomName?: string) {
+		const location = {x: pos.x, y: pos.y, roomName: pos.roomName || roomName};
+		Visualizer.text(text, location, 0.6, {
+			color: 'white',
+			backgroundColor: 'black',
+		});
+	}
+
 	static drawStructureMap(structureMap: StructureMap): void {
 		if (!this.enabled) return;
 		const vis: { [roomName: string]: RoomVisual } = {};


### PR DESCRIPTION
## Pull request summary

### Description:
This pr is a collection of little changes and tweaks that overall aims to provide a faster startup in both resource constrained and resource abundant rooms. 

### Added/Changed:

- Tweaked outpost logic to include how bored the spawn is in how likely adding more rooms should be
- Tweaked early queen behavior to include more queens (hurts efficiency but improves spawn saturation, especially when energy transportation is a problem)
- Tweaked bootstrap logic to use more fillers and reuse them as queens, greatly improving early efficiency and source saturation
- Tweaked bootstrap logic for established rooms to avoid the extremely slow upstart problem by gradually ramping up queen setups instead of going from smallest filler to biggest queen in one go
- Tweaked worker logic to aggressively go for energy drops when there is no containers but relax and stay at the container once it exists (this no longer starvers the spawn as we have multiple queens who still are a bit more aggressive)
- Fix a bug with one transport being there with no reason
- Bumped up worker count when there is no container yet to account for the transport costs and cheap workers
- Add one upgrader to rcl3 rooms to always keep the container in use and transports en route to it, keeps things flowing but feels a bit crude
- Reduce amount of workers/transporters spawned for remoted that are not producing any energy
- Fix bugs with migrations when run on completely fresh memory
- handle invaders/cores better, current dev sometimes deadlocks where it can't spawn the broodling it wants too or forgets the threat once workers flee
- Recharge over multiple rooms for early game and especially pioneers who now can utilize remotes
- Visualizer utility to mark structures/positions (useful for debugging)

## Testing checklist:

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on *{choose PUBLIC/PRIVATE}* server OR changes are trivial (e.g. typos)

