### PR TITLE
BUGFIX: BootstrappingOverlord fillers get stuck

### DIFF
--- a/src/overlords/situational/bootstrap.ts
+++ b/src/overlords/situational/bootstrap.ts
@@ -28,16 +28,15 @@ export class BootstrappingOverlord extends Overlord {
 	constructor(directive: DirectiveBootstrap, priority = OverlordPriority.emergency.bootstrap) {
 		super(directive, 'bootstrap', priority);
 		this.fillers = this.zerg(Roles.filler);
-		// Calculate structures fillers can supply / withdraw from
-		this.supplyStructures = _.filter([...this.colony.spawns, ...this.colony.extensions],
-										 structure => structure.energy < structure.energyCapacity);
-		this.withdrawStructures = _.filter(_.compact([this.colony.storage!,
-													  this.colony.terminal!,
-													  this.colony.powerSpawn!,
-													  ...this.room.containers,
-													  ...this.room.links,
-													  ...this.room.towers,
-													  ...this.room.labs]), structure => structure.energy > 0);
+		// Pick up all possible structures first
+		this.supplyStructures = [...this.colony.spawns, ...this.colony.extensions];
+		this.withdrawStructures = [this.colony.storage!,
+									this.colony.terminal!,
+									this.colony.powerSpawn!,
+									...this.room.containers,
+									...this.room.links,
+									...this.room.towers,
+									...this.room.labs];
 	}
 
 	private spawnBootstrapMiners() {
@@ -142,8 +141,15 @@ export class BootstrappingOverlord extends Overlord {
 	}
 
 	run() {
+		let toUpdate = true;
 		for (const filler of this.fillers) {
 			if (filler.isIdle) {
+				if (toUpdate) {
+					toUpdate = false
+					// Filter valid structures fillers can supply / withdraw from
+					this.supplyStructures = _.filter(this.supplyStructures, structure => structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+					this.withdrawStructures = _.filter(this.withdrawStructures, structure => structure.store.energy > 0);
+				}
 				this.handleFiller(filler);
 			}
 			filler.run();

--- a/src/overlords/situational/bootstrap.ts
+++ b/src/overlords/situational/bootstrap.ts
@@ -30,13 +30,13 @@ export class BootstrappingOverlord extends Overlord {
 		this.fillers = this.zerg(Roles.filler);
 		// Pick up all possible structures first
 		this.supplyStructures = [...this.colony.spawns, ...this.colony.extensions];
-		this.withdrawStructures = [this.colony.storage!,
-									this.colony.terminal!,
-									this.colony.powerSpawn!,
-									...this.room.containers,
-									...this.room.links,
-									...this.room.towers,
-									...this.room.labs];
+		this.withdrawStructures = _.compact([this.colony.storage!,
+											this.colony.terminal!,
+											this.colony.powerSpawn!,
+											...this.room.containers,
+											...this.room.links,
+											...this.room.towers,
+											...this.room.labs]);
 	}
 
 	private spawnBootstrapMiners() {


### PR DESCRIPTION
## Pull request summary

### Description:
<!--- Include a description of the changes in this pull request here --->
quick fix about this bug: only fetch all possible structures in constructor(), and call the filters at the tick which one of the fillers is idle. the PR is on the way.

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- None

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->
Fixes issue #196.


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on PUBLIC server (and changes are ... kind of ... trivial?)

