### PR TITLE
Feature: queen bunker filling logic tweaks

### DIFF
--- a/src/overlords/core/queen_bunker.ts
+++ b/src/overlords/core/queen_bunker.ts
@@ -161,7 +161,7 @@ export class BunkerQueenOverlord extends Overlord {
 					if (exceedAmount > 0) {
 						tasks.push(Tasks.transfer(transferTarget, res as ResourceConstant, exceedAmount))
 					} else if (exceedAmount < 0) {
-						queenCarry[res] -= exceedAmount
+						queenCarry[res] = -exceedAmount
 					}
 				}
 				queenPos = transferTarget.pos;

--- a/src/overlords/core/queen_bunker.ts
+++ b/src/overlords/core/queen_bunker.ts
@@ -119,18 +119,6 @@ export class BunkerQueenOverlord extends Overlord {
 	// Builds a series of tasks to empty unnecessary carry contents, withdraw required resources, and supply structures
 	private buildSupplyTaskManifest(queen: Zerg): Task | null {
 		let tasks: Task[] = [];
-		// Step 1: empty all contents (this shouldn't be necessary since queen is normally empty at this point)
-		let queenPos = queen.pos;
-		if (_.sum(queen.carry) > 0) {
-			const transferTarget = this.colony.terminal || this.colony.storage || this.batteries[0];
-			if (transferTarget) {
-				tasks.push(Tasks.transferAll(transferTarget));
-				queenPos = transferTarget.pos;
-			} else {
-				log.warning(`No transfer targets for ${queen.print}!`);
-				return null;
-			}
-		}
 		// Step 2: figure out what you need to supply for and calculate the needed resources
 		const queenCarry = {} as { [resourceType: string]: number };
 		const allStore = mergeSum(_.map(this.storeStructures, s => s.store));
@@ -149,7 +137,7 @@ export class BunkerQueenOverlord extends Overlord {
 			const remainingAmount = queen.carryCapacity - _.sum(queenCarry);
 			if (remainingAmount == 0) break;
 			// figure out how much you can withdraw
-			let amount = Math.min(request.amount, remainingAmount);
+			let amount: number | undefined = Math.min(request.amount, remainingAmount);
 			amount = Math.min(amount, allStore[request.resourceType] || 0);
 			if (amount == 0) continue;
 			// update the simulated carry
@@ -157,8 +145,30 @@ export class BunkerQueenOverlord extends Overlord {
 				queenCarry[request.resourceType] = 0;
 			}
 			queenCarry[request.resourceType] += amount;
+			// avoid auto regeneration conflict
+			if (request.target instanceof StructureSpawn && amount == request.amount) amount = undefined 
 			// add a task to supply the target
 			supplyTasks.push(Tasks.transfer(request.target, request.resourceType, amount));
+		}
+		// Step 1->2.5: decide what and how much to empty
+		let queenPos = queen.pos;
+		if (queen.carry.getUsedCapacity() > 0) {
+			const transferTarget = this.colony.terminal || this.colony.storage || this.batteries[0];
+			if (transferTarget) {
+				// tasks.push(Tasks.transferAll(transferTarget));
+				for (const res in queen.carry) {
+					const exceedAmount = queen.carry[res as ResourceConstant] - (queenCarry[res] || 0)
+					if (exceedAmount > 0) {
+						tasks.push(Tasks.transfer(transferTarget, res as ResourceConstant, exceedAmount))
+					} else if (exceedAmount < 0) {
+						queenCarry[res] -= exceedAmount
+					}
+				}
+				queenPos = transferTarget.pos;
+			} else {
+				log.warning(`No transfer targets for ${queen.print}!`);
+				return null;
+			}
 		}
 		// Step 3: make withdraw tasks to get the needed resources
 		const withdrawTasks: Task[] = [];

--- a/src/overlords/core/queen_bunker.ts
+++ b/src/overlords/core/queen_bunker.ts
@@ -146,7 +146,9 @@ export class BunkerQueenOverlord extends Overlord {
 			}
 			queenCarry[request.resourceType] += amount;
 			// avoid auto regeneration conflict
-			if (request.target instanceof StructureSpawn && amount == request.amount) amount = undefined 
+			if (request.target instanceof StructureSpawn && amount == request.amount) {
+				amount = undefined;
+			}
 			// add a task to supply the target
 			supplyTasks.push(Tasks.transfer(request.target, request.resourceType, amount));
 		}
@@ -157,11 +159,11 @@ export class BunkerQueenOverlord extends Overlord {
 			if (transferTarget) {
 				// tasks.push(Tasks.transferAll(transferTarget));
 				for (const res in queen.carry) {
-					const exceedAmount = queen.carry[res as ResourceConstant] - (queenCarry[res] || 0)
+					const exceedAmount = queen.carry[res as ResourceConstant] - (queenCarry[res] || 0);
 					if (exceedAmount > 0) {
-						tasks.push(Tasks.transfer(transferTarget, res as ResourceConstant, exceedAmount))
+						tasks.push(Tasks.transfer(transferTarget, res as ResourceConstant, exceedAmount));
 					} else if (exceedAmount < 0) {
-						queenCarry[res] = -exceedAmount
+						queenCarry[res] = -exceedAmount;
 					}
 				}
 				queenPos = transferTarget.pos;


### PR DESCRIPTION
## Pull request summary

### Description:
<!--- Include a description of the changes in this pull request here --->
alters the logic of queen_bunker overlord

### Added:
<!--- Include new features added with this pull request here --->

- None

### Changed:
<!--- Describe changes to existing features here --->

- Queens now calculate which types and how much certain filling task chain requires, then drop the exceeded and pick up other required
  - old code: `dump all` -> `calc sum`
  - new code: `calc sum` -> `calc needed (in one iteration with not too much cost)`
  - old task chain: `drop all (if needed)` -> `pick all` -> `transfer`
  - new task chain: `drop some` -> `pick others` -> `transfer`

### Removed:
<!--- List code or features that you have removed here --->

- None

### Fixed:
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- When at low RCL, some spawns uses up nearly all energy and triggers spawn to recover energy - then the spawn-filling task becomes invalid because of the exceeded energy assigned, causing one extra filling task.
- What I did is to change the certain amount to `undefined` to avoid over-filling failures
- energy left will be used in the next filling chain, no extra dropping, max efficiency

## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [x] Changes are backward-compatible OR version migration code is included (no memory change)
- [x] Codebase compiles with current `tsconfig` configuration (no config changes)
- [x] Tested changes on *PUBLIC* server (still running)

