### PR TITLE
Use typed-screeps types

### DIFF
--- a/src/caching/GlobalCache.ts
+++ b/src/caching/GlobalCache.ts
@@ -98,7 +98,7 @@ export class $ { // $ = cash = cache... get it? :D
 	}
 
 	static set<T extends HasRef, K extends keyof T>(thing: T, key: K,
-													callback: () => (T[K] & (undefined | HasID | HasID[])),
+													callback: () => (T[K] & (undefined | _HasId | _HasId[])),
 													timeout = CACHE_TIMEOUT): void {
 		const cacheKey = thing.ref + '$' + <string>key;
 		if (!_cache.things[cacheKey] || Game.time > _cache.expiration[cacheKey]) {
@@ -109,41 +109,41 @@ export class $ { // $ = cash = cache... get it? :D
 			// Refresh structure list by ID if not already done on current tick
 			if ((_cache.accessed[cacheKey] || 0) < Game.time) {
 				if (_.isArray(_cache.things[cacheKey])) {
-					_cache.things[cacheKey] = _.compact(_.map(_cache.things[cacheKey] as HasID[],
-															  s => Game.getObjectById(s.id))) as HasID[];
+					_cache.things[cacheKey] = _.compact(_.map(_cache.things[cacheKey] as _HasId[],
+															  s => Game.getObjectById(s.id))) as _HasId[];
 				} else {
-					_cache.things[cacheKey] = Game.getObjectById((<HasID>_cache.things[cacheKey]).id) as HasID;
+					_cache.things[cacheKey] = Game.getObjectById((<_HasId>_cache.things[cacheKey]).id) as _HasId;
 				}
 				_cache.accessed[cacheKey] = Game.time;
 			}
 		}
-		thing[key] = _cache.things[cacheKey] as T[K] & (undefined | HasID | HasID[]);
+		thing[key] = _cache.things[cacheKey] as T[K] & (undefined | _HasId | _HasId[]);
 	}
 
-	static refresh<T extends Record<K, undefined | HasID | HasID[]>, K extends string>(thing: T, ...keys: K[]): void {
+	static refresh<T extends Record<K, undefined | _HasId | _HasId[]>, K extends string>(thing: T, ...keys: K[]): void {
 		_.forEach(keys, function(key) {
 			if (thing[key]) {
 				if (_.isArray(thing[key])) {
-					thing[key] = _.compact(_.map(thing[key] as HasID[], s => Game.getObjectById(s.id))) as T[K];
+					thing[key] = _.compact(_.map(thing[key] as _HasId[], s => Game.getObjectById(s.id))) as T[K];
 				} else {
-					thing[key] = Game.getObjectById((<HasID>thing[key]).id) as T[K];
+					thing[key] = Game.getObjectById((<_HasId>thing[key]).id) as T[K];
 				}
 			}
 		});
 	}
 
-	static refreshObject<T extends Record<K, { [prop: string]: undefined | HasID | HasID[] }>,
+	static refreshObject<T extends Record<K, { [prop: string]: undefined | _HasId | _HasId[] }>,
 		K extends string>(thing: T, ...keys: K[]): void {
 		_.forEach(keys, function(key) {
 			if (_.isObject(thing[key])) {
 				for (const prop in thing[key]) {
 					if (_.isArray(thing[key][prop])) {
 						// @ts-ignore
-						thing[key][prop] = _.compact(_.map(thing[key][prop] as HasID[],
-														   s => Game.getObjectById(s.id))) as HasID[];
+						thing[key][prop] = _.compact(_.map(thing[key][prop] as _HasId[],
+														   s => Game.getObjectById(s.id))) as _HasId[];
 					} else {
 						// @ts-ignore
-						thing[key][prop] = Game.getObjectById((<HasID>thing[key][prop]).id) as undefined | HasID;
+						thing[key][prop] = Game.getObjectById((<_HasId>thing[key][prop]).id) as undefined | _HasId;
 					}
 				}
 			}

--- a/src/declarations/index.d.ts
+++ b/src/declarations/index.d.ts
@@ -63,7 +63,7 @@ interface IGlobalCache {
 	lists: { [key: string]: any[] };
 	costMatrices: { [key: string]: CostMatrix };
 	roomPositions: { [key: string]: RoomPosition | undefined };
-	things: { [key: string]: undefined | HasID | HasID[] };
+	things: { [key: string]: undefined | _HasId | _HasId[] };
 	// objects: { [key: string]: Object };
 }
 
@@ -291,16 +291,8 @@ interface ProtoPos {
 	roomName: string;
 }
 
-interface HasPos {
-	pos: RoomPosition;
-}
-
 interface HasRef {
 	ref: string;
-}
-
-interface HasID {
-	id: Id;
 }
 
 type AnyStoreStructure =

--- a/src/declarations/prototypes.d.ts
+++ b/src/declarations/prototypes.d.ts
@@ -74,7 +74,7 @@ interface Room {
 	threatLevel: number;
 	instantaneousThreatLevel: 0 | 0.5 | 1;
 
-	fleeDefaults: HasPos[];
+	fleeDefaults: _HasRoomPosition[];
 
 	structures: Structure[];
 	hostileStructures: Structure[];

--- a/src/declarations/typeGuards.ts
+++ b/src/declarations/typeGuards.ts
@@ -102,20 +102,20 @@ export function isSource(obj: Source | Mineral): obj is Source {
 	return (<Source>obj).energy != undefined;
 }
 
-export function isTombstone(obj: RoomObject | HasPos): obj is Tombstone {
+export function isTombstone(obj: RoomObject | _HasRoomPosition): obj is Tombstone {
 	return (<Tombstone>obj).deathTime != undefined;
 }
 
-export function isRuin(obj: RoomObject | HasPos): obj is Ruin {
+export function isRuin(obj: RoomObject | _HasRoomPosition): obj is Ruin {
 	return (<Ruin>obj).destroyTime != undefined;
 }
 
-export function isResource(obj: RoomObject | HasPos): obj is Resource {
+export function isResource(obj: RoomObject | _HasRoomPosition): obj is Resource {
 	return (<Resource>obj).amount != undefined;
 }
 
-export function hasPos(obj: HasPos | RoomPosition): obj is HasPos {
-	return (<HasPos>obj).pos != undefined;
+export function hasPos(obj: _HasRoomPosition | RoomPosition): obj is _HasRoomPosition {
+	return (<_HasRoomPosition>obj).pos != undefined;
 }
 
 export function isDirective(thing: any): thing is Directive {

--- a/src/matrix/MatrixLib.ts
+++ b/src/matrix/MatrixLib.ts
@@ -401,7 +401,7 @@ export class MatrixLib {
 	/**
 	 * Blocks all specified positions, setting their cost to 0xff
 	 */
-	static block(matrix: CostMatrix, positions: (RoomPosition | HasPos)[]): CostMatrix {
+	static block(matrix: CostMatrix, positions: (RoomPosition | _HasRoomPosition)[]): CostMatrix {
 		let pos: RoomPosition;
 		for (let i = 0; i < positions.length; i++) {
 			pos = normalizePos(positions[i]);
@@ -413,7 +413,7 @@ export class MatrixLib {
 	/**
 	 * Sets the cost of all positions to a value if walls are not present and if the value is above the current value
 	 */
-	static softBlock(matrix: CostMatrix, positions: (RoomPosition | HasPos)[],
+	static softBlock(matrix: CostMatrix, positions: (RoomPosition | _HasRoomPosition)[],
 					 roomName: string, cost: number): CostMatrix {
 		let pos: RoomPosition;
 		const terrain = Game.map.getRoomTerrain(roomName);
@@ -473,7 +473,7 @@ export class MatrixLib {
 	 *     0 2 2 2 2 2 0
 	 *     0 0 0 0 0 0 0
 	 */
-	static addPyramidPotential(matrix: CostMatrix, pos: RoomPosition | HasPos, range: number, maxCost: number,
+	static addPyramidPotential(matrix: CostMatrix, pos: RoomPosition | _HasRoomPosition, range: number, maxCost: number,
 							   includeTerrain             = true, // don't use includeTerrain with explicitTerrainCosts!
 							   terrainCosts: TerrainCosts = {plainCost: 1, swampCost: 5}): CostMatrix {
 
@@ -520,7 +520,7 @@ export class MatrixLib {
 	 * Adds a square potential with a specified center and range. If includeTerrainCosts=true (by default) then if the
 	 * cost for a square is zero, the terrain cost of the tile is added using default costs of {plain: 1, swamp: 5}.
 	 */
-	static addSquarePotential(matrix: CostMatrix, pos: RoomPosition | HasPos, range: number, addCost: number,
+	static addSquarePotential(matrix: CostMatrix, pos: RoomPosition | _HasRoomPosition, range: number, addCost: number,
 							  includeTerrain             = true, // don't use includeTerrain with explicitTerrainCosts!
 							  terrainCosts: TerrainCosts = {plainCost: 1, swampCost: 5}): CostMatrix {
 
@@ -588,7 +588,7 @@ export class MatrixLib {
 	 * -> Do not run additional passes of applyMovingMaxPool after doing this!
 	 * -> This method assumes that you have already added explicit terrian costs.
 	 */
-	static blockAfterMaxPooling(matrix: CostMatrix, positions: (RoomPosition | HasPos)[],
+	static blockAfterMaxPooling(matrix: CostMatrix, positions: (RoomPosition | _HasRoomPosition)[],
 								width: number, height: number): CostMatrix {
 		let pos: RoomPosition;
 		let x, y, dx, dy: number;
@@ -619,7 +619,7 @@ export class MatrixLib {
 	 * 0 9 0 0     0 9 5 0     9 9 5 1    |    0 9 0 0     9 9 1 1     9 9 5 1
 	 * 0 0 0 1     0 0 0 1     0 0 1 1    |    0 0 0 1     0 0 1 1     0 0 1 1
 	 */
-	static setToMaxCostAfterMaxPooling(matrix: CostMatrix, positions: (RoomPosition | HasPos)[],
+	static setToMaxCostAfterMaxPooling(matrix: CostMatrix, positions: (RoomPosition | _HasRoomPosition)[],
 									   width: number, height: number, cost: number): CostMatrix {
 		let pos: RoomPosition;
 		let x, y, dx, dy: number;
@@ -655,7 +655,7 @@ export class MatrixLib {
 	 * 0 9 0 0     0 9 5 0     9 9 5 1    |    0 9 0 0     9 9 1 1     9 9 6 1
 	 * 0 0 0 1     0 0 0 1     0 0 1 1    |    0 0 0 1     0 0 1 1     0 0 1 1
 	 */
-	static addCostAfterMaxPooling(matrix: CostMatrix, positions: (RoomPosition | HasPos)[],
+	static addCostAfterMaxPooling(matrix: CostMatrix, positions: (RoomPosition | _HasRoomPosition)[],
 								  width: number, height: number, cost: number): CostMatrix {
 		const addMatrix = new PathFinder.CostMatrix();
 		MatrixLib.setToMaxCostAfterMaxPooling(addMatrix, positions, width, height, cost);
@@ -668,7 +668,7 @@ export class MatrixLib {
 	 * to the existing cost of the tile. If the cost for a square is zero, the terrain cost of the tile is added
 	 * using implicit costs of {plain: 1, swamp: 5}
 	 */
-	static setInRange(matrix: CostMatrix, pos: RoomPosition | HasPos, range: number, cost: number,
+	static setInRange(matrix: CostMatrix, pos: RoomPosition | _HasRoomPosition, range: number, cost: number,
 					  addDefaultTerrainCosts = false): CostMatrix {
 
 		pos = normalizePos(pos);

--- a/src/movement/Movement.ts
+++ b/src/movement/Movement.ts
@@ -127,7 +127,7 @@ export class Movement {
 	/**
 	 * Move a creep to a destination
 	 */
-	static goTo(creep: AnyZerg, destination: HasPos | RoomPosition, opts: MoveOptions = {}): number {
+	static goTo(creep: AnyZerg, destination: _HasRoomPosition | RoomPosition, opts: MoveOptions = {}): number {
 
 		if (creep.blockMovement && !opts.force) {
 			return ERR_BUSY;
@@ -773,7 +773,7 @@ export class Movement {
 	/**
 	 * Moves a pair of creeps; the follower will always attempt to be in the last position of the leader
 	 */
-	static pairwiseMove(leader: AnyZerg, follower: AnyZerg, target: HasPos | RoomPosition,
+	static pairwiseMove(leader: AnyZerg, follower: AnyZerg, target: _HasRoomPosition | RoomPosition,
 						opts = {} as MoveOptions, allowedRange = 1): number | undefined {
 		let outcome;
 		if (leader.room != follower.room) {
@@ -813,7 +813,7 @@ export class Movement {
 	/**
 	 * Moves a swarm to a destination, accounting for group pathfinding
 	 */
-	static swarmMove(swarm: Swarm, destination: HasPos | RoomPosition, opts: SwarmMoveOptions = {}): number {
+	static swarmMove(swarm: Swarm, destination: _HasRoomPosition | RoomPosition, opts: SwarmMoveOptions = {}): number {
 
 		if (swarm.fatigue > 0) {
 			Movement.circle(swarm.anchor, 'aqua', .3);
@@ -1215,7 +1215,7 @@ export class Movement {
 	/**
 	 * Moving routine for guards or sourceReapers in a room with NPC invaders
 	 */
-	static invasionMove(creep: Zerg, destination: RoomPosition | HasPos, opts: MoveOptions = {}): number {
+	static invasionMove(creep: Zerg, destination: RoomPosition | _HasRoomPosition, opts: MoveOptions = {}): number {
 		_.defaults(opts, getDefaultMoveOptions());
 		const dest = normalizePos(destination);
 		if (creep.pos.getRangeTo(dest) > 8) {
@@ -1234,7 +1234,7 @@ export class Movement {
 	/**
 	 * Kite around enemies in a single room, repathing every tick. More expensive than flee().
 	 */
-	static kite(creep: AnyZerg, avoidGoals: (RoomPosition | HasPos)[], options: MoveOptions = {}): number | undefined {
+	static kite(creep: AnyZerg, avoidGoals: (RoomPosition | _HasRoomPosition)[], options: MoveOptions = {}): number | undefined {
 		_.defaults(options, {
 			fleeRange   : 5,
 			terrainCosts: isPowerZerg(creep) ? {plainCost: 1, swampCost: 1} : getTerrainCosts((<Creep>creep.creep)),
@@ -1248,7 +1248,7 @@ export class Movement {
 	/**
 	 * Flee from avoid goals in the room while not re-pathing every tick like kite() does.
 	 */
-	static flee(creep: AnyZerg, avoidGoals: (RoomPosition | HasPos)[],
+	static flee(creep: AnyZerg, avoidGoals: (RoomPosition | _HasRoomPosition)[],
 				dropEnergy = false, opts: MoveOptions = {}): number | undefined {
 
 		if (avoidGoals.length == 0) {

--- a/src/movement/Pathing.ts
+++ b/src/movement/Pathing.ts
@@ -488,7 +488,7 @@ export class Pathing {
 	/**
 	 * Get a kiting path within a room
 	 */
-	static findKitingPath(creepPos: RoomPosition, fleeFrom: (RoomPosition | HasPos)[],
+	static findKitingPath(creepPos: RoomPosition, fleeFrom: (RoomPosition | _HasRoomPosition)[],
 						  opts: PathOptions = {}): PathFinderPath {
 		_.defaults(opts, {
 			fleeRange   : 5,
@@ -511,7 +511,7 @@ export class Pathing {
 	/**
 	 * Get a flee path possibly leaving the room; generally called further in advance of kitingPath
 	 */
-	static findFleePath(creepPos: RoomPosition, fleeFrom: (RoomPosition | HasPos)[],
+	static findFleePath(creepPos: RoomPosition, fleeFrom: (RoomPosition | _HasRoomPosition)[],
 						opts: PathOptions = {}): PathFinderPath {
 		_.defaults(opts, {
 			terrainCosts: {plainCost: 1, swampCost: 5},
@@ -1139,7 +1139,7 @@ export class Pathing {
 	 * Whether another object in the same room can be reached from the current position.
 	 * This method is very expensive and kind of stupid, so use it sparingly!
 	 */
-	static isReachable(startPos: RoomPosition, endPos: RoomPosition, obstacles: (RoomPosition | HasPos)[],
+	static isReachable(startPos: RoomPosition, endPos: RoomPosition, obstacles: (RoomPosition | _HasRoomPosition)[],
 					   options: PathOptions = {}): boolean {
 		_.defaults(options, {
 			blockCreeps: false,
@@ -1182,7 +1182,7 @@ export class Pathing {
 	/**
 	 * Like isReachable(), but returns the first position which should be cleared to find a path to destination
 	 */
-	static findBlockingPos(startPos: RoomPosition, endPos: RoomPosition, obstacles: (RoomPosition | HasPos)[],
+	static findBlockingPos(startPos: RoomPosition, endPos: RoomPosition, obstacles: (RoomPosition | _HasRoomPosition)[],
 						   options: PathOptions = {}): RoomPosition | undefined {
 		_.defaults(options, {
 			blockCreeps: false,

--- a/src/movement/helpers.ts
+++ b/src/movement/helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Returns destination.pos if destination has a position, or destination if destination is a RoomPosition
  */
-export function normalizePos(destination: HasPos | RoomPosition): RoomPosition {
+export function normalizePos(destination: _HasRoomPosition | RoomPosition): RoomPosition {
 	return (<any>destination).pos || destination;
 }
 

--- a/src/tasks/instances/drop.ts
+++ b/src/tasks/instances/drop.ts
@@ -1,7 +1,7 @@
 import {profile} from '../../profiler/decorator';
 import {Task} from '../Task';
 
-export type dropTargetType = HasRef & HasPos; // Currently these are only used with directives
+export type dropTargetType = HasRef & _HasRoomPosition; // Currently these are only used with directives
 export const dropTaskName = 'drop';
 
 @profile

--- a/src/tasks/instances/goTo.ts
+++ b/src/tasks/instances/goTo.ts
@@ -3,7 +3,7 @@ import {profile} from '../../profiler/decorator';
 import {Task} from '../Task';
 
 // export type goToTargetType = { pos: RoomPosition } | RoomPosition;
-export type goToTargetType = HasRef & HasPos;  // This is overridden and handled better in the Tasks.goTo() dispatcher
+export type goToTargetType = HasRef & _HasRoomPosition;  // This is overridden and handled better in the Tasks.goTo() dispatcher
 export const goToTaskName = 'goTo';
 
 @profile

--- a/src/tasks/instances/goToRoom.ts
+++ b/src/tasks/instances/goToRoom.ts
@@ -3,7 +3,7 @@ import {Task} from '../Task';
 
 
 // export type goToRoomTargetType = string;
-export type goToRoomTargetType = HasRef & HasPos;  // This is handled better in the Tasks.goToRoom() dispatcher
+export type goToRoomTargetType = HasRef & _HasRoomPosition;  // This is handled better in the Tasks.goToRoom() dispatcher
 
 export const goToRoomTaskName = 'goToRoom';
 

--- a/src/tasks/instances/recharge.ts
+++ b/src/tasks/instances/recharge.ts
@@ -9,7 +9,7 @@ import {TaskHarvest} from './harvest';
 import {pickupTaskName, TaskPickup} from './pickup';
 import {TaskWithdraw, withdrawTaskName} from './withdraw';
 
-export type rechargeTargetType = HasRef & HasPos;  // This is handled better in the Tasks.recharge() dispatcher
+export type rechargeTargetType = HasRef & _HasRoomPosition;  // This is handled better in the Tasks.recharge() dispatcher
 // export type rechargeTargetType = null;
 export const rechargeTaskName = 'recharge';
 

--- a/src/zerg/AnyZerg.ts
+++ b/src/zerg/AnyZerg.ts
@@ -332,7 +332,7 @@ export abstract class AnyZerg {
 
 	// Movement and location -------------------------------------------------------------------------------------------
 
-	goTo(destination: RoomPosition | HasPos, options: MoveOptions = {}) {
+	goTo(destination: RoomPosition | _HasRoomPosition, options: MoveOptions = {}) {
 		return Movement.goTo(this, destination, options);
 	}
 
@@ -340,7 +340,7 @@ export abstract class AnyZerg {
 		return Movement.goToRoom(this, roomName, options);
 	}
 
-	inSameRoomAs(target: HasPos): boolean {
+	inSameRoomAs(target: _HasRoomPosition): boolean {
 		return this.pos.roomName == target.pos.roomName;
 	}
 
@@ -360,7 +360,7 @@ export abstract class AnyZerg {
 	/**
 	 * Kite around hostiles in the room
 	 */
-	kite(avoidGoals: (RoomPosition | HasPos)[] = this.room.hostiles, options: MoveOptions = {}): number | undefined {
+	kite(avoidGoals: (RoomPosition | _HasRoomPosition)[] = this.room.hostiles, options: MoveOptions = {}): number | undefined {
 		_.defaults(options, {
 			fleeRange: 5
 		});
@@ -368,7 +368,7 @@ export abstract class AnyZerg {
 	}
 
 	private defaultFleeGoals() {
-		let fleeGoals: (RoomPosition | HasPos)[] = [];
+		let fleeGoals: (RoomPosition | _HasRoomPosition)[] = [];
 		fleeGoals = fleeGoals.concat(this.room.hostiles)
 							 .concat(_.filter(this.room.keeperLairs, lair => (lair.ticksToSpawn || Infinity) < 10));
 		return fleeGoals;
@@ -377,7 +377,7 @@ export abstract class AnyZerg {
 	/**
 	 * Flee from hostiles in the room, while not repathing every tick // TODO: take a look at this
 	 */
-	flee(avoidGoals: (RoomPosition | HasPos)[] = this.room.fleeDefaults,
+	flee(avoidGoals: (RoomPosition | _HasRoomPosition)[] = this.room.fleeDefaults,
 		 fleeOptions: FleeOptions              = {},
 		 moveOptions: MoveOptions              = {}): boolean {
 		if (avoidGoals.length == 0 || this.room.dangerousHostiles.find(

--- a/src/zerg/NeuralZerg.ts
+++ b/src/zerg/NeuralZerg.ts
@@ -41,7 +41,7 @@ export class NeuralZerg extends CombatZerg {
 		return Movement.combatMove(this, [], avoid);
 	}
 
-	maneuver(approachTargs: HasPos[], avoidTargs: HasPos[]) {
+	maneuver(approachTargs: _HasRoomPosition[], avoidTargs: _HasRoomPosition[]) {
 		const approach = _.map(approachTargs, targ => ({pos: targ.pos, range: APPROACH_RANGE}));
 		const avoid = _.map(avoidTargs, targ => ({pos: targ.pos, range: AVOID_RANGE}));
 		return Movement.combatMove(this, approach, avoid);

--- a/src/zerg/Swarm.ts
+++ b/src/zerg/Swarm.ts
@@ -337,7 +337,7 @@ export class Swarm implements ProtoSwarm {
 
 	// Range finding methods ===========================================================================================
 
-	minRangeTo(obj: RoomPosition | HasPos): number {
+	minRangeTo(obj: RoomPosition | _HasRoomPosition): number {
 		if (hasPos(obj)) {
 			return _.min(_.map(this.creeps, creep =>
 				creep.pos.roomName === obj.pos.roomName ? creep.pos.getRangeToXY(obj.pos.x, obj.pos.y) : Infinity));
@@ -347,7 +347,7 @@ export class Swarm implements ProtoSwarm {
 		}
 	}
 
-	maxRangeTo(obj: RoomPosition | HasPos): number {
+	maxRangeTo(obj: RoomPosition | _HasRoomPosition): number {
 		if (hasPos(obj)) {
 			return _.max(_.map(this.creeps, creep =>
 				creep.pos.roomName === obj.pos.roomName ? creep.pos.getRangeToXY(obj.pos.x, obj.pos.y) : Infinity));
@@ -357,7 +357,7 @@ export class Swarm implements ProtoSwarm {
 		}
 	}
 
-	findInMinRange(targets: HasPos[], range: number): HasPos[] {
+	findInMinRange(targets: _HasRoomPosition[], range: number): _HasRoomPosition[] {
 		const initialRange = range + Math.max(this.width, this.height) - 1;
 		const targetsInRange = _.filter(targets, t => this.anchor.inRangeToXY(t.pos.x, t.pos.y, initialRange));
 		return _.filter(targetsInRange, t => this.minRangeTo(t) <= range);
@@ -366,7 +366,7 @@ export class Swarm implements ProtoSwarm {
 	/**
 	 * Compute the "average" direction to a target
 	 */
-	getDirectionTo(obj: RoomPosition | HasPos): DirectionConstant {
+	getDirectionTo(obj: RoomPosition | _HasRoomPosition): DirectionConstant {
 		const pos = normalizePos(obj);
 		const directions = _.map(this.creeps, creep => creep.pos.getDirectionTo(obj));
 		// TODO
@@ -519,7 +519,7 @@ export class Swarm implements ProtoSwarm {
 		return allMoved ? OK : ERR_NOT_ALL_OK;
 	}
 
-	goTo(destination: RoomPosition | HasPos, options: SwarmMoveOptions = {}): number {
+	goTo(destination: RoomPosition | _HasRoomPosition, options: SwarmMoveOptions = {}): number {
 		// if (DEBUG) {
 		// 	options.displayCostMatrix = true;
 		// }
@@ -588,7 +588,7 @@ export class Swarm implements ProtoSwarm {
 	}
 
 	private getBestOrientation(room: Room, includeStructures = true, includeCreeps = false): TOP | RIGHT | BOTTOM | LEFT {
-		const targets: HasPos[] = [];
+		const targets: _HasRoomPosition[] = [];
 		if (includeStructures) {
 			const structureTargets = this.findInMinRange(room.hostileStructures, 1);
 			for (const structure of structureTargets) {
@@ -823,7 +823,7 @@ export class Swarm implements ProtoSwarm {
 	/**
 	 * Groups enemies into proto-swarms based on proximity to each other
 	 */
-	static findEnemySwarms(room: Room, anchor?: HasPos, maxClumpSize = 3): ProtoSwarm[] {
+	static findEnemySwarms(room: Room, anchor?: _HasRoomPosition, maxClumpSize = 3): ProtoSwarm[] {
 		const enemySwarms: ProtoSwarm[] = [];
 		const origin = anchor || _.first(room.spawns) || room.controller || {pos: new RoomPosition(25, 25, room.name)};
 		let attackers = _.sortBy(room.dangerousHostiles, creep => origin.pos.getRangeTo(creep));


### PR DESCRIPTION
## Pull request summary

This changes two of our types to the typed-screeps names:
- `HasID` -> `_HasId`
- `HasPos` -> `_HasRoomPosition`

## Testing checklist:

- [x] Changes are backward-compatible OR version migration code is included
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Changes are trivial (project-wide rename)

