### PR TITLE
RoomObject.print

### DIFF
--- a/src/declarations/prototypes.d.ts
+++ b/src/declarations/prototypes.d.ts
@@ -134,6 +134,7 @@ interface Room {
 }
 
 interface RoomObject {
+	print: string;
 	ref: string;
 	targetedBy: string[];
 

--- a/src/declarations/typeGuards.ts
+++ b/src/declarations/typeGuards.ts
@@ -8,24 +8,6 @@ import {NeuralZerg} from '../zerg/NeuralZerg';
 import {PowerZerg} from '../zerg/PowerZerg';
 import {Zerg} from '../zerg/Zerg';
 
-// export interface EnergyStructure extends Structure {
-// 	energy: number;
-// 	energyCapacity: number;
-// }
-
-// export interface StoreStructure extends Structure {
-// 	store: StoreDefinition;
-// 	storeCapacity: number;
-// }
-
-// export function isEnergyStructure(obj: RoomObject): obj is EnergyStructure {
-// 	return (<EnergyStructure>obj).energy != undefined && (<EnergyStructure>obj).energyCapacity != undefined;
-// }
-//
-// export function isStoreStructure(obj: RoomObject): obj is StoreStructure {
-// 	return (<StoreStructure>obj).store != undefined && (<StoreStructure>obj).storeCapacity != undefined;
-// }
-
 export function isStructure(obj: RoomObject): obj is Structure {
 	return (<Structure>obj).structureType != undefined;
 }
@@ -98,7 +80,7 @@ export function isFactory(structure: Structure): structure is StructureFactory {
 	return structure.structureType == STRUCTURE_FACTORY;
 }
 
-export function isSource(obj: Source | Mineral): obj is Source {
+export function isSource(obj: RoomObject): obj is Source {
 	return (<Source>obj).energy != undefined;
 }
 
@@ -112,6 +94,19 @@ export function isRuin(obj: RoomObject | HasPos): obj is Ruin {
 
 export function isResource(obj: RoomObject | HasPos): obj is Resource {
 	return (<Resource>obj).amount != undefined;
+}
+
+export function isConstructionSite(obj: RoomObject): obj is ConstructionSite {
+	const site = (<ConstructionSite>obj);
+	return site.progress !== undefined && site.structureType !== undefined;
+}
+
+export function isMineral(obj: RoomObject): obj is Mineral {
+	return (<Mineral>obj).mineralType !== undefined;
+}
+
+export function isDeposit(obj: RoomObject): obj is Deposit {
+	return (<Deposit>obj).depositType !== undefined;
 }
 
 export function hasPos(obj: HasPos | RoomPosition): obj is HasPos {

--- a/src/prototypes/RoomObject.ts
+++ b/src/prototypes/RoomObject.ts
@@ -1,4 +1,43 @@
+import {
+	isConstructionSite,
+	isCreep,
+	isDeposit,
+	isMineral,
+	isResource,
+	isRuin,
+	isSource,
+	isStructure,
+	isTombstone,
+} from "declarations/typeGuards";
+
 // RoomObject prototypes
+
+export function roomObjectType(obj: RoomObject) {
+	let type;
+	if (isRuin(obj)) type = "ruin";
+	else if (isTombstone(obj)) type = "tombstone";
+	else if (isResource(obj)) type = "resource";
+	else if (isStructure(obj)) type = obj.structureType;
+	else if (isSource(obj)) type = "source";
+	else if (isMineral(obj)) type = `mineral of ${obj.mineralType}`;
+	else if (isDeposit(obj)) type = `deposit of ${obj.depositType}`;
+	else if (isConstructionSite(obj)) type = `${obj.structureType} (site)`;
+	else if (obj instanceof PowerCreep) {
+		type = `powercreep ${obj.name} (owned by ${obj.owner.username})`;
+	} else if (isCreep(obj)) {
+		type = `creep ${obj.name} (owned by ${obj.owner.username})`;
+	} else {
+		type = "unknown";
+	}
+	return type;
+}
+
+Object.defineProperty(RoomObject.prototype, "print", {
+	get(this: RoomObject) {
+		return `${roomObjectType(this)} ${this.pos.print}`;
+	},
+	configurable: true,
+});
 
 Object.defineProperty(RoomObject.prototype, 'ref', { // reference object; see globals.deref (which includes Creep)
 	get         : function() {


### PR DESCRIPTION
## Pull request summary

### Description:
This adds a RoomObject-level `.print` method, so that it's safe to print any sort of object. I believe it is missing a couple cases, but it covers most of them.

## Testing checklist:

- [x] Changes are backward-compatible
- [x] Codebase compiles with current `tsconfig` configuration
- [x] Tested changes on private server

